### PR TITLE
fix(monitors): fit display previews to modal regardless of layout

### DIFF
--- a/src/components/MonitorsModal.tsx
+++ b/src/components/MonitorsModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useMonitorStore, type MonitorSelection } from "../stores/monitors";
 import { useShallow } from "zustand/react/shallow";
 import { MonitorComponent } from "./Monitor";
-import { calculateMinResolution } from "../utils/utilities";
+import { fitMonitorLayout } from "../utils/utilities";
 import type { monitorSelectType } from "../types/rendererTypes";
 import { useModalStore } from "../stores/modalStore";
 import Modal, { type ModalHandle } from "./Modal";
@@ -31,8 +31,6 @@ function Monitors() {
   const [refreshKey, setRefreshKey] = useState(0);
 
   const live = useLiveWallpapers(monitorsList, refreshKey);
-
-  const resolution = calculateMinResolution(monitorsList);
 
   const prevModeRef = useRef(monitorSelection.mode);
   if (monitorSelection.mode !== prevModeRef.current) {
@@ -122,11 +120,14 @@ function Monitors() {
     closeModal();
   };
 
-  const scale = 1 / ((monitorsList.length + 1) * (screen.availWidth / window.innerWidth));
-  const isSingleMonitor = monitorsList.length === 1;
+  const previewBox = {
+    width: Math.min(window.innerWidth * 0.6, 640),
+    height: Math.min(window.innerHeight * 0.5, 400),
+  };
+  const layout = fitMonitorLayout(monitorsList, previewBox);
   const styles: React.CSSProperties = {
-    width: isSingleMonitor ? monitorsList[0].width * scale : resolution.x * scale,
-    height: isSingleMonitor ? monitorsList[0].height * scale : resolution.y * scale,
+    width: layout.width,
+    height: layout.height,
   };
 
   const neoFieldset = cn(
@@ -170,10 +171,10 @@ function Monitors() {
           </p>
         </fieldset>
 
-        <div style={styles} className="relative m-auto">
+        <div style={styles} data-testid="monitor-layout" className="relative m-auto">
           {monitorsList.map((monitor, index) => {
-            const left = isSingleMonitor ? 0 : monitor.x * scale;
-            const top = isSingleMonitor ? 0 : monitor.y * scale;
+            const left = (monitor.x - layout.origin.x) * layout.scale;
+            const top = (monitor.y - layout.origin.y) * layout.scale;
             const key = `m-${index}-${monitor.x}-${monitor.y}-${monitor.width}x${monitor.height}-${monitor.refresh_rate}-${monitor.transform}`;
 
             return (
@@ -190,7 +191,7 @@ function Monitors() {
                   monitorsList={monitorsList}
                   monitor={monitor}
                   selectType={selectType}
-                  scale={scale * 0.99}
+                  scale={layout.scale * 0.99}
                   live={live}
                 />
               </div>

--- a/src/components/__tests__/MonitorsModal.test.tsx
+++ b/src/components/__tests__/MonitorsModal.test.tsx
@@ -54,10 +54,6 @@ vi.mock("../Monitor", () => ({
   ),
 }));
 
-vi.mock("../../utils/utilities", () => ({
-  calculateMinResolution: () => ({ x: 1920, y: 1080 }),
-}));
-
 HTMLDialogElement.prototype.showModal = HTMLDialogElement.prototype.showModal ?? vi.fn();
 HTMLDialogElement.prototype.close = HTMLDialogElement.prototype.close ?? vi.fn();
 
@@ -137,6 +133,34 @@ describe("MonitorsModal", () => {
     await waitFor(() => {
       expect(screen.getByText("Select at least two displays")).toBeInTheDocument();
     });
+  });
+
+  it("scales stacked monitors to fit the preview box (issue #225)", () => {
+    // 1600x900 window → preview box of 640x400 (min(60vw, 640) x min(50vh, 400))
+    const originalWidth = window.innerWidth;
+    const originalHeight = window.innerHeight;
+    Object.defineProperty(window, "innerWidth", { value: 1600, configurable: true });
+    Object.defineProperty(window, "innerHeight", { value: 900, configurable: true });
+
+    try {
+      // Two 2560x1440 monitors stacked vertically: bbox 2560x2880, height binds.
+      const top = { ...makeMonitor("DP-1", false), width: 2560, height: 1440 };
+      const bottom = { ...makeMonitor("eDP-1", false, 0, 1440), width: 2560, height: 1440 };
+      mockMonitorsList = [top, bottom];
+
+      render(<Monitors />);
+
+      const scale = 400 / 2880;
+      const layout = screen.getByTestId("monitor-layout");
+      expect(parseFloat(layout.style.width)).toBeCloseTo(2560 * scale, 1);
+      expect(parseFloat(layout.style.height)).toBeCloseTo(400, 1);
+
+      const bottomWrapper = screen.getByTestId("monitor-eDP-1").parentElement as HTMLElement;
+      expect(parseFloat(bottomWrapper.style.top)).toBeCloseTo(1440 * scale, 1);
+    } finally {
+      Object.defineProperty(window, "innerWidth", { value: originalWidth, configurable: true });
+      Object.defineProperty(window, "innerHeight", { value: originalHeight, configurable: true });
+    }
   });
 
   it("calls setMonitorSelection on valid individual submit", async () => {

--- a/src/utils/__tests__/utilities.test.ts
+++ b/src/utils/__tests__/utilities.test.ts
@@ -4,7 +4,7 @@ import {
   toSeconds,
   toHoursAndMinutes,
   parseResolution,
-  calculateMinResolution,
+  fitMonitorLayout,
 } from "../utilities";
 import type { Image, Monitor } from "../../../electron/daemon-go-types";
 
@@ -143,76 +143,67 @@ describe("parseResolution", () => {
   });
 });
 
-describe("calculateMinResolution", () => {
-  it("calculates bounding box for single monitor", () => {
-    const monitors: Monitor[] = [
-      {
-        name: "A",
-        width: 1920,
-        height: 1080,
-        x: 0,
-        y: 0,
-        scale: 1,
-        refresh_rate: 60,
-        transform: 0,
-      },
-    ];
-    expect(calculateMinResolution(monitors)).toEqual({ x: 1920, y: 1080 });
+describe("fitMonitorLayout", () => {
+  const box = { width: 600, height: 400 };
+
+  function monitor(name: string, width: number, height: number, x: number, y: number): Monitor {
+    return { name, width, height, x, y, scale: 1, refresh_rate: 60, transform: 0 };
+  }
+
+  it("fits stacked monitors by height so the layout never exceeds the box", () => {
+    // Issue #225: two 2560x1440 monitors stacked vertically (bbox 2560x2880).
+    const monitors = [monitor("DP-1", 2560, 1440, 0, 0), monitor("eDP-1", 2560, 1440, 0, 1440)];
+
+    const layout = fitMonitorLayout(monitors, box);
+
+    // Height is the binding constraint: 400 / 2880
+    expect(layout.scale).toBeCloseTo(400 / 2880);
+    expect(layout.width).toBeCloseTo(2560 * (400 / 2880));
+    expect(layout.height).toBeCloseTo(400);
+    expect(layout.width).toBeLessThanOrEqual(box.width);
+    expect(layout.height).toBeLessThanOrEqual(box.height);
   });
 
-  it("calculates bounding box for side-by-side monitors", () => {
-    const monitors: Monitor[] = [
-      {
-        name: "A",
-        width: 1920,
-        height: 1080,
-        x: 0,
-        y: 0,
-        scale: 1,
-        refresh_rate: 60,
-        transform: 0,
-      },
-      {
-        name: "B",
-        width: 2560,
-        height: 1440,
-        x: 1920,
-        y: 0,
-        scale: 1,
-        refresh_rate: 144,
-        transform: 0,
-      },
-    ];
-    expect(calculateMinResolution(monitors)).toEqual({ x: 4480, y: 1440 });
+  it("fits side-by-side monitors by width", () => {
+    const monitors = [monitor("A", 2560, 1440, 0, 0), monitor("B", 2560, 1440, 2560, 0)];
+
+    const layout = fitMonitorLayout(monitors, box);
+
+    // Width is the binding constraint: 600 / 5120
+    expect(layout.scale).toBeCloseTo(600 / 5120);
+    expect(layout.width).toBeCloseTo(600);
+    expect(layout.height).toBeCloseTo(1440 * (600 / 5120));
   });
 
-  it("calculates bounding box for stacked monitors", () => {
-    const monitors: Monitor[] = [
-      {
-        name: "A",
-        width: 1920,
-        height: 1080,
-        x: 0,
-        y: 0,
-        scale: 1,
-        refresh_rate: 60,
-        transform: 0,
-      },
-      {
-        name: "B",
-        width: 1920,
-        height: 1080,
-        x: 0,
-        y: 1080,
-        scale: 1,
-        refresh_rate: 60,
-        transform: 0,
-      },
-    ];
-    expect(calculateMinResolution(monitors)).toEqual({ x: 1920, y: 2160 });
+  it("normalizes negative origins so all positions stay inside the layout", () => {
+    const monitors = [monitor("A", 1920, 1080, -1920, 0), monitor("B", 1920, 1080, 0, 0)];
+
+    const layout = fitMonitorLayout(monitors, box);
+
+    expect(layout.origin).toEqual({ x: -1920, y: 0 });
+    // Bounding box is 3840x1080; width binds: 600 / 3840
+    expect(layout.scale).toBeCloseTo(600 / 3840);
+    expect(layout.width).toBeCloseTo(600);
+    // Position of monitor A relative to origin lands at 0, B at half the width
+    expect((monitors[0].x - layout.origin.x) * layout.scale).toBeCloseTo(0);
+    expect((monitors[1].x - layout.origin.x) * layout.scale).toBeCloseTo(300);
   });
 
-  it("returns zeros for empty array", () => {
-    expect(calculateMinResolution([])).toEqual({ x: 0, y: 0 });
+  it("fits a single monitor", () => {
+    const layout = fitMonitorLayout([monitor("A", 1920, 1080, 0, 0)], box);
+
+    // Width binds: 600 / 1920
+    expect(layout.scale).toBeCloseTo(600 / 1920);
+    expect(layout.width).toBeCloseTo(600);
+    expect(layout.height).toBeCloseTo(1080 * (600 / 1920));
+  });
+
+  it("returns an empty layout for no monitors", () => {
+    expect(fitMonitorLayout([], box)).toEqual({
+      scale: 0,
+      width: 0,
+      height: 0,
+      origin: { x: 0, y: 0 },
+    });
   });
 });

--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -42,22 +42,45 @@ export function parseResolution(resolution: string) {
   return { width: parseInt(width, 10), height: parseInt(height, 10) };
 }
 
-export function calculateMinResolution(monitors: Monitor[]) {
-  let maxWidth = 0;
-  let maxHeight = 0;
+export interface MonitorLayoutFit {
+  /** Multiplier from layout pixels to preview pixels. */
+  scale: number;
+  /** Scaled size of the whole layout's bounding box. */
+  width: number;
+  height: number;
+  /** Top-left of the bounding box in layout coordinates (can be negative). */
+  origin: { x: number; y: number };
+}
 
-  for (const monitor of monitors) {
-    const effectiveWidth = monitor.width + monitor.x;
-    const effectiveHeight = monitor.height + monitor.y;
-
-    if (effectiveWidth > maxWidth) {
-      maxWidth = effectiveWidth;
-    }
-
-    if (effectiveHeight > maxHeight) {
-      maxHeight = effectiveHeight;
-    }
+/**
+ * Scales a monitor arrangement so its bounding box fits inside `box`,
+ * preserving aspect ratio. Positions relative to the preview are
+ * `(monitor.x - origin.x) * scale` / `(monitor.y - origin.y) * scale`.
+ */
+export function fitMonitorLayout(
+  monitors: Monitor[],
+  box: { width: number; height: number },
+): MonitorLayoutFit {
+  if (monitors.length === 0) {
+    return { scale: 0, width: 0, height: 0, origin: { x: 0, y: 0 } };
   }
 
-  return { x: maxWidth, y: maxHeight };
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const monitor of monitors) {
+    minX = Math.min(minX, monitor.x);
+    minY = Math.min(minY, monitor.y);
+    maxX = Math.max(maxX, monitor.x + monitor.width);
+    maxY = Math.max(maxY, monitor.y + monitor.height);
+  }
+
+  const scale = Math.min(box.width / (maxX - minX), box.height / (maxY - minY));
+  return {
+    scale,
+    width: (maxX - minX) * scale,
+    height: (maxY - minY) * scale,
+    origin: { x: minX, y: minY },
+  };
 }


### PR DESCRIPTION
## What

Fixes #225 — the Choose Display modal rendered oversized, overflowing monitor previews for vertically stacked monitors.

## Why

The preview scale was a heuristic (`1 / ((count + 1) * screen.availWidth / window.innerWidth)`) that only made sense for monitors arranged in a horizontal row: it assumed the virtual desktop width grows with monitor count, and never considered the layout's height at all. With two stacked monitors, the bounding box is one monitor wide and two tall, so the previews blew past the modal bounds (see the screenshot in #225).

## How

- New pure `fitMonitorLayout(monitors, box)` in `src/utils/utilities.ts`: computes the layout bounding box (normalized for negative x/y origins) and scales it to fit a preview box, preserving aspect ratio — the same approach display-settings layout maps use.
- `MonitorsModal` now fits the arrangement into `min(60vw, 640px) × min(50vh, 400px)` and positions each monitor relative to the bounding-box origin. The single-monitor special case became unnecessary.
- Removed `calculateMinResolution`, which this change orphaned.

## Tests

Written test-first (red-green): 5 unit tests for `fitMonitorLayout` (stacked #225 repro, side-by-side, negative origins, single, empty) plus a component test asserting a stacked layout renders within the preview box. Full suite: 426 passing, tsc/format clean.