### PR TITLE
docs: add first-run tutorial and SSE reference, enforce dead links

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -28,7 +28,7 @@ export default defineConfig({
       },
     ],
   ],
-  ignoreDeadLinks: true,
+  ignoreDeadLinks: false,
   themeConfig: {
     logo: "/logo.png",
     nav: [
@@ -42,6 +42,7 @@ export default defineConfig({
           text: "Getting started",
           items: [
             { text: "Install & run", link: "/guide/install" },
+            { text: "First 10 minutes", link: "/guide/first-run" },
             { text: "The app (UI)", link: "/guide/app" },
             { text: "FAQ & troubleshooting", link: "/guide/faq" },
           ],
@@ -62,14 +63,20 @@ export default defineConfig({
           text: "Control plane",
           items: [
             { text: "Overview", link: "/api/overview" },
-            { text: "OpenAPI spec & curl examples", link: "/api/openapi" },
+            {
+              text: "OpenAPI spec (GitHub)",
+              link: "https://github.com/0bCdian/Waypaper-Engine/blob/main/daemon/docs/openapi.yaml",
+            },
           ],
         },
         {
           text: "Integration",
           items: [
             { text: "Events & SSE", link: "/api/sse" },
-            { text: "Authoritative reference", link: "/api/contract" },
+            {
+              text: "API contract (GitHub)",
+              link: "https://github.com/0bCdian/Waypaper-Engine/blob/main/daemon/API_CONTRACT.md",
+            },
           ],
         },
       ],

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -5,7 +5,7 @@ The daemon speaks **JSON** over **HTTP/1.1** on a **Unix domain socket** . The r
 | Topic                                              | Where                                                                                                        |
 | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | Human-oriented prose, examples, and models         | [API contract (GitHub)](https://github.com/0bCdian/Waypaper-Engine/blob/main/daemon/API_CONTRACT.md)         |
-| Machine-readable path map and `operationId` values | [OpenAPI spec](/api/openapi) (also `daemon/docs/openapi.yaml` in the repo)                                   |
+| Machine-readable path map and `operationId` values | [OpenAPI spec (GitHub)](https://github.com/0bCdian/Waypaper-Engine/blob/main/daemon/docs/openapi.yaml) (`daemon/docs/openapi.yaml` in the repo) |
 | **SSE** event types and filters                    | [Events & SSE](/api/sse)                                                                                     |
 | **Architecture** (packages, data, backends)        | [ARCHITECTURE.md (GitHub)](https://github.com/0bCdian/Waypaper-Engine/blob/main/daemon/docs/ARCHITECTURE.md) |
 
@@ -43,4 +43,4 @@ curl -sS --unix-socket -X POST "$SOCK" "http://localhost/wallpaper/random" \
 
 **NOTE** — _Electron UI:_ the renderer uses `daemonClient` (from `src/client/`) → preload bridge → `"daemon"` IPC channel → main process → socket. It never calls the socket directly. See the **bridge** section in the [API contract](https://github.com/0bCdian/Waypaper-Engine/blob/main/daemon/API_CONTRACT.md#electron-renderer-bridge-notes).
 
-**NOTE** — _No browser try-it:_ the daemon binds a Unix domain socket, not TCP. Browser-based “try it” tools cannot reach it. Use `curl --unix-socket` — see [OpenAPI spec & curl examples](/api/openapi) for copy-pasteable commands.
+**NOTE** — _No browser try-it:_ the daemon binds a Unix domain socket, not TCP. Browser-based “try it” tools cannot reach it. Use `curl --unix-socket` — see the examples above and in [Events & SSE](/api/sse).

--- a/docs/api/sse.md
+++ b/docs/api/sse.md
@@ -1,0 +1,115 @@
+# Events & SSE
+
+Everything that happens in the daemon — wallpaper changes, playlist activity, imports, config edits — is published on an internal event bus and streamed to clients over **Server-Sent Events** at `GET /events`. Subscribe once, react forever; no polling.
+
+Implementation: `daemon/internal/server/sse.go` (broker) and `daemon/internal/events/types.go` (event types).
+
+---
+
+## Connecting
+
+```bash
+# Everything
+curl -N --unix-socket "${XDG_RUNTIME_DIR}/waypaper-engine.sock" http://localhost/events
+
+# Only what you care about
+curl -N --unix-socket "${XDG_RUNTIME_DIR}/waypaper-engine.sock" \
+  "http://localhost/events?types=wallpaper_changed,playlist_started"
+```
+
+Or skip `curl` entirely — the CLI wraps the stream and prints each event as a **JSON line**, which pipes nicely into `jq`:
+
+```bash
+waypaper-daemon events
+waypaper-daemon events --types wallpaper_changed,playlist_started
+```
+
+**Filtering:** `?types=` takes a comma-separated list of event types. Omit it (or pass `*`) to receive everything.
+
+---
+
+## Wire format
+
+Standard SSE: an `event:` line with the type, a `data:` line with a JSON payload, blank-line separated. Every payload includes a `timestamp` field (injected by the broker).
+
+```
+event: wallpaper_changed
+data: {"monitor":"DP-1", ..., "timestamp":"2026-07-09T23:00:00Z"}
+
+: keepalive
+```
+
+> [!NOTE]
+> The `: keepalive` comment is sent every **30 seconds** so dead connections get detected. SSE-aware clients ignore comment lines automatically; if you parse by hand, skip lines starting with `:`.
+
+---
+
+## Event types
+
+From `daemon/internal/events/types.go` — this table tracks the code, not the other way around.
+
+### Wallpaper
+
+| Type | When |
+| --- | --- |
+| `wallpaper_changed` | A wallpaper was applied on any monitor (manual, random, or playlist). |
+| `wallpaper_apply_failed` | A backend failed to apply a wallpaper. |
+| `wallpaper_restore_failed` | One or more monitors could not restore their persisted wallpaper on daemon startup. |
+
+### Playlists
+
+| Type | When |
+| --- | --- |
+| `playlist_started` | A playlist began running. |
+| `playlist_stopped` | A playlist stopped. |
+| `playlist_paused` | A playlist was paused. |
+| `playlist_resumed` | A paused playlist resumed. |
+| `playlist_image_changed` | A running playlist advanced to another image. |
+| `playlist_skipped_incompatible` | Items incompatible with the active backend were skipped. |
+| `playlist_no_compatible_item` | The whole playlist was exhausted with nothing the active backend can display. |
+
+### Import & processing
+
+Emitted during batch image import.
+
+| Type | When |
+| --- | --- |
+| `processing_started` | A batch import began. |
+| `image_processed` | One image finished processing (thumbnails, palette, ...). |
+| `image_error` | One image failed to process. |
+| `processing_complete` | The batch finished. |
+| `processing_cancelled` | The batch was cancelled. |
+
+### Monitors, config & gallery
+
+| Type | When |
+| --- | --- |
+| `monitor_connected` | An output appeared. |
+| `monitor_disconnected` | An output went away. |
+| `config_changed` | Config was updated (any writer: UI, CLI, `PATCH /config`). |
+| `gallery_changed` | Any gallery collection changed. The payload's `domain` field says which: `images`, `folders`, `playlists`, or `history`. Treat it as a "re-fetch that collection" signal. |
+| `image_orphan_purged` | All database references to a deleted image were removed. |
+
+### Backend lifecycle
+
+| Type | When |
+| --- | --- |
+| `backend_unavailable` | A long-lived renderer backend (e.g. wal-qt) could not be reached after retries. |
+
+---
+
+## Recipes
+
+React to every wallpaper change (e.g. re-theme your terminal):
+
+```bash
+waypaper-daemon events --types wallpaper_changed | while read -r line; do
+  echo "wallpaper changed: $line"
+  # your pywal/matugen/whatever hook here
+done
+```
+
+> [!NOTE]
+> The daemon binds a **Unix socket**, not TCP — a browser `EventSource` can't reach it directly. Use `curl -N --unix-socket`, the CLI, or any HTTP client that speaks Unix sockets.
+
+Exact payload shapes per event live in the [API contract](https://github.com/0bCdian/Waypaper-Engine/blob/main/daemon/API_CONTRACT.md).

--- a/docs/guide/first-run.md
+++ b/docs/guide/first-run.md
@@ -1,0 +1,88 @@
+# First 10 minutes
+
+From zero to a wallpaper on your screen, and a playlist rotating on its own. This is the happy path — every step links to a deeper page if you want the details. If you're the scripting type, there's a taste of the API at the end.
+
+**Prerequisites:**
+
+- A Wayland or X11 compositor.
+- One backend binary on `PATH` — for Wayland images, [`awww`](https://github.com/LGFae/awww) is the recommended start. See [Backends & dependencies](/guide/backends) for the full menu.
+- On wlroots compositors (Hyprland, sway, ...): [`wlr-randr`](https://sr.ht/~emersion/wlr-randr/) for reliable monitor detection.
+
+> [!NOTE]
+> No backend installed yet? The app still launches — you'll see a banner with an install link, and it clears on its own once a backend appears on `PATH`.
+
+---
+
+## 1. Install
+
+On Arch, simply:
+
+```bash
+yay -S waypaper-engine
+```
+
+Every other method (AppImage, from source, daemon-only) lives in [Install & run](/guide/install).
+
+## 2. Launch it
+
+Start **Waypaper Engine** from your app launcher, or:
+
+```bash
+waypaper-engine
+```
+
+The daemon starts automatically in the background if it isn't already running — it keeps running after you close the window, so playlists don't die with the GUI.
+
+## 3. Pick your backend
+
+Open **Settings → Backend** and select the one you installed (e.g. `awww`). Backends missing from `PATH` are greyed out. `auto` mode picks a backend per media type — you can come back for that later ([Backend settings](/guide/app#backend)).
+
+## 4. Choose your displays
+
+If you have more than one monitor, the **Choose Display** modal (monitor button in the top bar) shows your actual layout. Pick between:
+
+- **Wallpaper per display** — each monitor gets its own image.
+- **Clone** — same image everywhere.
+- **Stretch** — one image spanning all monitors (static images only).
+
+Single monitor? Skip this — it just works.
+
+## 5. Import wallpapers
+
+Drag and drop images, videos, or whole folders onto the window (or use the import button in the toolbar). Thumbnails, color palettes, and tags are generated in the background — progress shows inline. Formats and details: [The app — Gallery](/guide/app#gallery).
+
+## 6. Set one
+
+**Double-click** any image. That's your wallpaper.
+
+**Right-click** for more: set on a specific monitor, set random, tags, folders, rename, delete.
+
+## 7. Make it rotate — your first playlist
+
+1. Hover images in the gallery and tick the **checkbox** that appears — they land in the playlist track at the bottom.
+2. Hit **Configure** on the track and pick a schedule: **timer** (every N seconds), **manual** (next/prev only), **time of day**, or **day of week**.
+3. **Save**, give it a name, and start it.
+
+The playlist runs **in the daemon** — close the window, it keeps going.
+
+And you're done! Wallpaper set, playlist rotating.
+
+---
+
+## Day two (for the scripting type)
+
+Everything the UI does goes through a JSON HTTP API on a Unix socket, and everything that happens emits an event you can subscribe to:
+
+```bash
+# Is the daemon happy?
+curl --unix-socket "${XDG_RUNTIME_DIR}/waypaper-engine.sock" http://localhost/healthz
+
+# Watch wallpaper changes live, as JSON lines
+waypaper-daemon events --types wallpaper_changed
+```
+
+Run the daemon headless (no GUI at all) from your compositor's autostart — see [Daemon only](/guide/install#daemon-only-headless-autostart). Full API surface: [API overview](/api/overview) · [Events & SSE](/api/sse).
+
+---
+
+_Something didn't work? [FAQ & troubleshooting](/guide/faq) covers the common failure modes — and if yours isn't there, open an issue with your compositor and backend._

--- a/docs/guide/glossary.md
+++ b/docs/guide/glossary.md
@@ -26,4 +26,4 @@ Short definitions of terms used across these docs. Authoritative behavior (flags
 - **waypaper-engine** vs **waypaper-daemon**: the **GUI** vs the **long-lived service + CLI**; both may run together on a normal desktop.
 - **Socket path** (where the HTTP API listens) is unrelated to the **socket your compositor** might use — only the Waypaper **daemon** `socket_path` matters for `curl` and `waypaper-daemon`.
 
-If a term is missing, search the [FAQ](./faq) or the [OpenAPI spec](/api/openapi) for the feature name.
+If a term is missing, search the [FAQ](./faq) or the [OpenAPI spec](https://github.com/0bCdian/Waypaper-Engine/blob/main/daemon/docs/openapi.yaml) for the feature name.

--- a/docs/guide/whats-new.md
+++ b/docs/guide/whats-new.md
@@ -38,4 +38,4 @@ See [The app — Wallhaven](/guide/app#wallhaven-wallhaven).
 
 ## Migration assumptions
 
-If you are carrying notes from older versions, treat [the API contract on GitHub](https://github.com/0bCdian/Waypaper-Engine/blob/main/daemon/API_CONTRACT.md) and [OpenAPI](/api/openapi) as the current surface; the daemon’s [`routes.go` on GitHub](https://github.com/0bCdian/Waypaper-Engine/blob/main/daemon/internal/server/routes.go) is the final word on which paths exist.
+If you are carrying notes from older versions, treat [the API contract on GitHub](https://github.com/0bCdian/Waypaper-Engine/blob/main/daemon/API_CONTRACT.md) and [OpenAPI](https://github.com/0bCdian/Waypaper-Engine/blob/main/daemon/docs/openapi.yaml) as the current surface; the daemon’s [`routes.go` on GitHub](https://github.com/0bCdian/Waypaper-Engine/blob/main/daemon/internal/server/routes.go) is the final word on which paths exist.


### PR DESCRIPTION
Adds the "First 10 minutes" tutorial and the Events & SSE reference — both were linked from the sidebar but never written, hidden by `ignoreDeadLinks: true`. OpenAPI/contract links now point at GitHub, and dead links fail the docs build from now on.