### PR TITLE
feat: hue filter strip, Rainbow sort, and color picker in gallery

### DIFF
--- a/daemon/API_CONTRACT.md
+++ b/daemon/API_CONTRACT.md
@@ -103,13 +103,14 @@ Paginated, sortable, filterable image gallery.
 | ------------- | ------ | ------------- | -------------------------------------------------------------------------------------------------------------- |
 | `page`        | int    | `1`           | Page number (1-indexed)                                                                                        |
 | `per_page`    | int    | `50`          | Items per page (max 200)                                                                                       |
-| `sort_by`     | string | `imported_at` | Sort field: `name`, `imported_at`, `file_size`                                                                 |
+| `sort_by`     | string | `imported_at` | Sort field: `name`, `imported_at`, `file_size`, `hue` (rainbow order: hue group asc/desc, neutral last, saturation desc within group; in-memory) |
 | `sort_order`  | string | `desc`        | Sort direction: `asc`, `desc`                                                                                  |
 | `media_type`  | string | —             | Filter: `image`, `video`, `gif`                                                                                |
 | `search`      | string | —             | Case-insensitive fuzzy search on name/tags                                                                     |
 | `tags`        | string | —             | Comma-separated tag filter                                                                                     |
 | `colors`      | string | —             | Comma-separated dominant color filter (hex; each must appear as a swatch, AND)                                 |
 | `colors_near` | string | —             | Comma-separated `#hex~maxDeltaE` perceptual match (CIE76 vs stored palette; AND); forces in-memory filter path |
+| `hue_group`   | int    | —             | Hue group filter: 0–11 (30° buckets, red-centered) or 99 (neutral); computed from the stored palette; forces in-memory filter path |
 | `folder_id`   | string | —             | Folder filter (`root`/`0` for root, or ID)                                                                     |
 
 **Response** `200`:

--- a/daemon/internal/cielab/hue.go
+++ b/daemon/internal/cielab/hue.go
@@ -1,0 +1,79 @@
+package cielab
+
+import "math"
+
+// NeutralHueGroup is the hue group for palettes with no chromatic swatch
+// (grayscale / near-black / near-white images).
+const NeutralHueGroup = 99
+
+// Chromatic swatch thresholds (HSL). A swatch below the saturation floor or
+// outside the lightness band reads as neutral to the eye and is skipped when
+// picking the palette's representative hue.
+const (
+	minChromaticSaturation = 0.18
+	minChromaticLightness  = 0.12
+	maxChromaticLightness  = 0.92
+)
+
+// HueGroupFromPalette returns the 30°-bucket hue group (0-11, red-centered:
+// hue >= 345° or < 15° → 0) of the first chromatic swatch in dominance order,
+// or NeutralHueGroup when no swatch qualifies. Invalid hexes are skipped.
+func HueGroupFromPalette(swatches []string) int {
+	group, _ := HueSortKey(swatches)
+	return group
+}
+
+// HueSortKey returns the hue group plus the winning swatch's HSL saturation,
+// for rainbow ordering (group asc, saturation desc). Neutral → (99, 0).
+func HueSortKey(swatches []string) (int, float64) {
+	for _, hex := range swatches {
+		r, g, b, ok := hexToRGB(hex)
+		if !ok {
+			continue
+		}
+		h, s, l := rgbToHSL(r, g, b)
+		if s < minChromaticSaturation || l < minChromaticLightness || l > maxChromaticLightness {
+			continue
+		}
+		return hueBucket(h), s
+	}
+	return NeutralHueGroup, 0
+}
+
+// hueBucket maps a hue in [0, 360) to a red-centered 30° bucket: shifting by
+// +15° makes [345, 360)∪[0, 15) land in bucket 0.
+func hueBucket(h float64) int {
+	shifted := math.Mod(h+15, 360)
+	return int(shifted/30) % 12
+}
+
+func rgbToHSL(r, g, b uint8) (h, s, l float64) {
+	rf := float64(r) / 255
+	gf := float64(g) / 255
+	bf := float64(b) / 255
+	max := math.Max(rf, math.Max(gf, bf))
+	min := math.Min(rf, math.Min(gf, bf))
+	l = (max + min) / 2
+	d := max - min
+	if d == 0 {
+		return 0, 0, l
+	}
+	if l > 0.5 {
+		s = d / (2 - max - min)
+	} else {
+		s = d / (max + min)
+	}
+	switch max {
+	case rf:
+		h = math.Mod((gf-bf)/d, 6)
+	case gf:
+		h = (bf-rf)/d + 2
+	default:
+		h = (rf-gf)/d + 4
+	}
+	h *= 60
+	if h < 0 {
+		h += 360
+	}
+	return h, s, l
+}

--- a/daemon/internal/cielab/hue_test.go
+++ b/daemon/internal/cielab/hue_test.go
@@ -1,0 +1,54 @@
+package cielab
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHueGroupFromPalette(t *testing.T) {
+	tests := []struct {
+		name     string
+		swatches []string
+		want     int
+	}{
+		{"pure red", []string{"#ff0000"}, 0},
+		{"red wraps high hue (350deg)", []string{"#ff002b"}, 0}, // hue ≈ 350
+		{"orange (30deg)", []string{"#ff8000"}, 1},              // hue ≈ 30
+		{"yellow (60deg)", []string{"#ffff00"}, 2},              // hue = 60
+		{"green (120deg)", []string{"#00ff00"}, 4},              // hue = 120
+		{"cyan (180deg)", []string{"#00ffff"}, 6},               // hue = 180
+		{"blue (240deg)", []string{"#0000ff"}, 8},               // hue = 240
+		{"magenta (300deg)", []string{"#ff00ff"}, 10},           // hue = 300
+		{"pink (330deg)", []string{"#ff0080"}, 11},              // hue = 330
+		{"dominance order wins: first chromatic swatch", []string{"#0000ff", "#ff0000"}, 8},
+		{"skips achromatic dominant swatch", []string{"#808080", "#ff0000"}, 0},
+		{"skips near-black swatch", []string{"#160505", "#00ff00"}, 4}, // lightness < 0.12
+		{"skips near-white swatch", []string{"#fdf3f2", "#00ff00"}, 4}, // lightness > 0.92
+		{"all gray is neutral", []string{"#111111", "#808080", "#eeeeee"}, NeutralHueGroup},
+		{"empty palette is neutral", nil, NeutralHueGroup},
+		{"invalid hex skipped", []string{"nope", "#00ff00"}, 4},
+		{"only invalid hex is neutral", []string{"zzz"}, NeutralHueGroup},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, HueGroupFromPalette(tt.swatches))
+		})
+	}
+}
+
+func TestHueSortKey(t *testing.T) {
+	g, s := HueSortKey([]string{"#ff0000"})
+	assert.Equal(t, 0, g)
+	assert.InDelta(t, 1.0, s, 0.001) // pure red: HSL saturation 1
+
+	g, s = HueSortKey([]string{"#808080"})
+	assert.Equal(t, NeutralHueGroup, g)
+	assert.Equal(t, 0.0, s)
+
+	// Muted but chromatic red (#b06060: sat ≈ 0.34) still lands in group 0 with its own saturation.
+	g, s = HueSortKey([]string{"#b06060"})
+	assert.Equal(t, 0, g)
+	assert.Greater(t, s, 0.18)
+	assert.Less(t, s, 0.6)
+}

--- a/daemon/internal/handler/imageshandler/images.go
+++ b/daemon/internal/handler/imageshandler/images.go
@@ -63,12 +63,13 @@ func NewImageHandler(
 // @Tags         images
 // @Param        page        query     int     false  "Page number"
 // @Param        per_page    query     int     false  "Items per page"
-// @Param        sort_by     query     string  false  "Sort field"
+// @Param        sort_by     query     string  false  "Sort field (name, imported_at, file_size, hue)"
 // @Param        sort_order  query     string  false  "asc or desc"
 // @Param        media_type  query     string  false  "Filter by media type"
 // @Param        search      query     string  false  "Search query"
 // @Param        tags        query     string  false  "Comma-separated tags"
 // @Param        colors_near           query     string  false  "Comma-separated #hex~maxDeltaE (CIE76)"
+// @Param        hue_group             query     int     false  "Hue group filter: 0-11 (30° buckets, red-centered) or 99 (neutral)"
 // @Param        palette_similar_to    query     int     false  "Show images with palette within ΔE of this image's palette"
 // @Param        palette_max_delta_e   query     number  false  "Max CIE76 ΔE (default 18)"
 // @Param        folder_id             query     string  false  "Folder ID or 'root'"
@@ -98,6 +99,15 @@ func (h *ImageHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	if cn := strings.TrimSpace(q.Get("colors_near")); cn != "" {
 		opts.ColorsNear = parseColorsNearQuery(cn)
+	}
+
+	if hg := strings.TrimSpace(q.Get("hue_group")); hg != "" {
+		v, ok := parseHueGroupParam(hg)
+		if !ok {
+			httpjson.WriteError(w, http.StatusBadRequest, "invalid hue_group")
+			return
+		}
+		opts.HueGroup = &v
 	}
 
 	if pst := strings.TrimSpace(q.Get("palette_similar_to")); pst != "" {
@@ -850,4 +860,16 @@ func parseColorsNearQuery(raw string) []store.ColorNearConstraint {
 		out = append(out, store.ColorNearConstraint{Hex: hex, MaxDeltaE: maxDE})
 	}
 	return out
+}
+
+// parseHueGroupParam validates the hue_group query value: 0-11 or 99.
+func parseHueGroupParam(raw string) (int, bool) {
+	v, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil {
+		return 0, false
+	}
+	if (v >= 0 && v <= 11) || v == 99 {
+		return v, true
+	}
+	return 0, false
 }

--- a/daemon/internal/handler/imageshandler/images_hue_test.go
+++ b/daemon/internal/handler/imageshandler/images_hue_test.go
@@ -1,0 +1,34 @@
+package imageshandler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseHueGroupParam(t *testing.T) {
+	tests := []struct {
+		raw    string
+		want   int
+		wantOK bool
+	}{
+		{"0", 0, true},
+		{"11", 11, true},
+		{"99", 99, true},
+		{" 5 ", 5, true},
+		{"12", 0, false},
+		{"-1", 0, false},
+		{"98", 0, false},
+		{"abc", 0, false},
+		{"", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			got, ok := parseHueGroupParam(tt.raw)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/daemon/internal/store/image_store_impl.go
+++ b/daemon/internal/store/image_store_impl.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 
 	clover "github.com/ostafen/clover/v2"
@@ -70,17 +71,22 @@ func (s *imageStore) GetAll(ctx context.Context, opts ImageQueryOpts) (*Paginate
 	}
 
 	sortField := "imported_at"
-	if opts.SortBy != "" {
+	if opts.SortBy != "" && opts.SortBy != "hue" {
 		sortField = opts.SortBy
 	}
 	sortDir := -1
 	if strings.ToLower(opts.SortOrder) == "asc" {
 		sortDir = 1
 	}
+	// Rainbow sort happens in memory; pin the DB pre-sort to newest-first so
+	// in-group ties resolve to imported_at desc via the stable sort below.
+	if opts.SortBy == "hue" {
+		sortDir = -1
+	}
 
 	// When search, root-folder filtering, perceptual color constraints, or palette similarity
 	// are active, load all DB-filtered docs, apply in-memory filters, then paginate in Go.
-	if opts.Search != "" || filterRootFolder || len(opts.ColorsNear) > 0 || opts.PaletteSimilarTo != nil {
+	if opts.Search != "" || filterRootFolder || len(opts.ColorsNear) > 0 || opts.PaletteSimilarTo != nil || opts.HueGroup != nil || opts.SortBy == "hue" {
 		q := query.NewQuery(CollectionImages)
 		if criteria != nil {
 			q = q.Where(criteria)
@@ -110,6 +116,12 @@ func (s *imageStore) GetAll(ctx context.Context, opts ImageQueryOpts) (*Paginate
 				maxDE = DefaultPaletteSimilarMaxDeltaE
 			}
 			allImages = filterImagesByPaletteSimilarity(allImages, refPalette, maxDE)
+		}
+		if opts.HueGroup != nil {
+			allImages = filterImagesByHueGroup(allImages, *opts.HueGroup)
+		}
+		if opts.SortBy == "hue" {
+			sortImagesByHue(allImages, strings.ToLower(opts.SortOrder) == "desc")
 		}
 
 		return Paginate(allImages, opts.Page, opts.PerPage), nil
@@ -334,4 +346,46 @@ func filterImagesByPaletteSimilarity(images []Image, ref []string, maxDE float64
 		}
 	}
 	return filtered
+}
+
+// filterImagesByHueGroup keeps images whose palette maps to the given hue group.
+func filterImagesByHueGroup(images []Image, group int) []Image {
+	filtered := make([]Image, 0, len(images))
+	for _, im := range images {
+		if cielab.HueGroupFromPalette(im.Colors) == group {
+			filtered = append(filtered, im)
+		}
+	}
+	return filtered
+}
+
+// sortImagesByHue orders images rainbow-style: hue group ascending (or
+// descending), neutral group always last, most-saturated first within a
+// group. Stable, so the caller's imported_at pre-sort breaks remaining ties.
+func sortImagesByHue(images []Image, desc bool) {
+	type hueKey struct {
+		group int
+		sat   float64
+	}
+	keys := make(map[int]hueKey, len(images))
+	for _, im := range images {
+		g, s := cielab.HueSortKey(im.Colors)
+		keys[im.ID] = hueKey{group: g, sat: s}
+	}
+	sort.SliceStable(images, func(i, j int) bool {
+		a, b := keys[images[i].ID], keys[images[j].ID]
+		if a.group != b.group {
+			if a.group == cielab.NeutralHueGroup {
+				return false
+			}
+			if b.group == cielab.NeutralHueGroup {
+				return true
+			}
+			if desc {
+				return a.group > b.group
+			}
+			return a.group < b.group
+		}
+		return a.sat > b.sat
+	})
 }

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -43,7 +43,8 @@ type ImageQueryOpts struct {
 	Page int
 	// Items per page. Default: 50, max: 200.
 	PerPage int
-	// Sort field: "name", "imported_at", "file_size". Default: "imported_at".
+	// Sort field: "name", "imported_at", "file_size", or "hue" (rainbow:
+	// hue group asc/desc, neutral last, saturation desc within a group).
 	SortBy string
 	// Sort direction: "asc" or "desc". Default: "desc".
 	SortOrder string
@@ -58,6 +59,10 @@ type ImageQueryOpts struct {
 	// ColorsNear filters by CIE76 ΔE in Lab vs stored swatches (AND across constraints).
 	// When non-empty, GetAll uses an in-memory filter path (same as text search).
 	ColorsNear []ColorNearConstraint
+	// HueGroup filters to images whose palette's dominant chromatic swatch
+	// falls in this 30° hue bucket (0-11) or cielab.NeutralHueGroup (99).
+	// Computed on the fly from Colors; forces the in-memory filter path.
+	HueGroup *int
 	// PaletteSimilarTo filters images whose palette is within PaletteSimilarMaxDeltaE of the
 	// reference image's palette (minimum CIE76 ΔE across all swatch pairs). Nil disables.
 	// Forces the in-memory filter path. Reference image must exist or GetAll returns ErrNotFound.

--- a/daemon/internal/store/store_test.go
+++ b/daemon/internal/store/store_test.go
@@ -103,6 +103,89 @@ func TestImageStore_GetAll_ColorsNear(t *testing.T) {
 	assert.Equal(t, "near_red.png", res.Data[0].Name)
 }
 
+func TestImageStore_GetAll_HueGroupFilter(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	is := db.ImageStore()
+	ctx := context.Background()
+
+	imgRed := testutil.SampleImage(0)
+	imgRed.Name = "red"
+	imgRed.Checksum = "sha256:hue_red"
+	imgRed.Colors = []string{"#ff0000", "#808080"}
+
+	imgBlue := testutil.SampleImage(0)
+	imgBlue.Name = "blue"
+	imgBlue.Checksum = "sha256:hue_blue"
+	imgBlue.Colors = []string{"#0000ff"}
+
+	imgGray := testutil.SampleImage(0)
+	imgGray.Name = "gray"
+	imgGray.Checksum = "sha256:hue_gray"
+	imgGray.Colors = []string{"#808080"}
+
+	_, err := is.Create(ctx, []store.Image{imgRed, imgBlue, imgGray})
+	require.NoError(t, err)
+
+	red := 0
+	res, err := is.GetAll(ctx, store.ImageQueryOpts{HueGroup: &red, Page: 1, PerPage: 50})
+	require.NoError(t, err)
+	require.Len(t, res.Data, 1)
+	assert.Equal(t, "red", res.Data[0].Name)
+
+	neutral := 99
+	res, err = is.GetAll(ctx, store.ImageQueryOpts{HueGroup: &neutral, Page: 1, PerPage: 50})
+	require.NoError(t, err)
+	require.Len(t, res.Data, 1)
+	assert.Equal(t, "gray", res.Data[0].Name)
+}
+
+func TestImageStore_GetAll_SortByHue(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	is := db.ImageStore()
+	ctx := context.Background()
+
+	imgGray := testutil.SampleImage(0)
+	imgGray.Name = "gray"
+	imgGray.Checksum = "sha256:sorthue_gray"
+	imgGray.Colors = []string{"#808080"}
+
+	imgBlue := testutil.SampleImage(0)
+	imgBlue.Name = "blue"
+	imgBlue.Checksum = "sha256:sorthue_blue"
+	imgBlue.Colors = []string{"#0000ff"}
+
+	imgMutedRed := testutil.SampleImage(0)
+	imgMutedRed.Name = "mutedred"
+	imgMutedRed.Checksum = "sha256:sorthue_mutedred"
+	imgMutedRed.Colors = []string{"#b06060"}
+
+	imgVividRed := testutil.SampleImage(0)
+	imgVividRed.Name = "vividred"
+	imgVividRed.Checksum = "sha256:sorthue_vividred"
+	imgVividRed.Colors = []string{"#ff0000"}
+
+	_, err := is.Create(ctx, []store.Image{imgGray, imgBlue, imgMutedRed, imgVividRed})
+	require.NoError(t, err)
+
+	res, err := is.GetAll(ctx, store.ImageQueryOpts{SortBy: "hue", SortOrder: "asc", Page: 1, PerPage: 50})
+	require.NoError(t, err)
+	require.Len(t, res.Data, 4)
+	// Rainbow asc: group 0 (vivid before muted red), then group 8, neutral last.
+	assert.Equal(t, "vividred", res.Data[0].Name)
+	assert.Equal(t, "mutedred", res.Data[1].Name)
+	assert.Equal(t, "blue", res.Data[2].Name)
+	assert.Equal(t, "gray", res.Data[3].Name)
+
+	// desc reverses group order but neutral stays last.
+	res, err = is.GetAll(ctx, store.ImageQueryOpts{SortBy: "hue", SortOrder: "desc", Page: 1, PerPage: 50})
+	require.NoError(t, err)
+	require.Len(t, res.Data, 4)
+	assert.Equal(t, "blue", res.Data[0].Name)
+	assert.Equal(t, "vividred", res.Data[1].Name)
+	assert.Equal(t, "mutedred", res.Data[2].Name)
+	assert.Equal(t, "gray", res.Data[3].Name)
+}
+
 func TestImageStore_GetAll_PaletteSimilarTo(t *testing.T) {
 	db := testutil.OpenTestDB(t)
 	is := db.ImageStore()

--- a/docs/superpowers/plans/2026-07-09-hue-filter-rainbow-sort.md
+++ b/docs/superpowers/plans/2026-07-09-hue-filter-rainbow-sort.md
@@ -1,0 +1,837 @@
+# Hue Filter Strip + Rainbow Sort Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** One-click hue filter strip (12 hue groups + neutral) in the gallery filter bar, plus a "Rainbow" sort mode, both computed daemon-side from the stored per-image k-means palette.
+
+**Architecture:** Hue group is derived on the fly from `Image.Colors` (hexes ordered by dominance) inside the daemon's existing in-memory query path in `imageStore.GetAll`. New `hue_group` query param + `sort_by=hue`. Client adds `hueGroup` to `Filters`, a 5th sort-cycle state, and a `HueFilterStrip` component in the filter bar.
+
+**Tech Stack:** Go 1.26 (daemon, testify), React 19 + TypeScript + Zustand (renderer, vitest), Tailwind/DaisyUI.
+
+## Global Constraints
+
+- Work in worktree `/home/obsy/dev/waypaper/.worktrees/waypaper-engine-hue` on branch `feat/hue-filter-rainbow-sort`. All paths below are relative to that directory.
+- TDD: write the failing test first, watch it fail, then implement. Commit after each green cycle.
+- Package manager is **pnpm only** (never npm/npx). Go tests: `pnpm run test:daemon:unit` or targeted `go test` from `daemon/`.
+- Formatters: gofmt for Go (`pnpm run gofmt:check`), oxfmt/oxlint for TS (`pnpm run format:check && pnpm run lint:check`). Match surrounding code style exactly; no drive-by refactors.
+- Hue group domain: integers **0–11** (30° buckets, red-centered) and **99** (neutral). Chromatic swatch thresholds: saturation ≥ **0.18**, lightness in **[0.12, 0.92]** (HSL).
+- No compatibility shims; the daemon HTTP contract may change freely but must be reflected in `daemon/API_CONTRACT.md`.
+
+---
+
+### Task 1: Hue bucketing in the `cielab` package (Go)
+
+**Files:**
+- Create: `daemon/internal/cielab/hue.go`
+- Test: `daemon/internal/cielab/hue_test.go`
+
+**Interfaces:**
+- Consumes: `hexToRGB(hex string) (r, g, b uint8, ok bool)` — already exists unexported in `daemon/internal/cielab/cielab.go:102`.
+- Produces (used by Task 2):
+  - `const NeutralHueGroup = 99`
+  - `func HueGroupFromPalette(swatches []string) int` — group of the first chromatic swatch, else `NeutralHueGroup`.
+  - `func HueSortKey(swatches []string) (group int, saturation float64)` — same group plus the winning swatch's HSL saturation (neutral → `(99, 0)`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `daemon/internal/cielab/hue_test.go`:
+
+```go
+package cielab
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHueGroupFromPalette(t *testing.T) {
+	tests := []struct {
+		name     string
+		swatches []string
+		want     int
+	}{
+		{"pure red", []string{"#ff0000"}, 0},
+		{"red wraps high hue (350deg)", []string{"#ff002b"}, 0},   // hue ≈ 350
+		{"orange (30deg)", []string{"#ff8000"}, 1},                 // hue ≈ 30
+		{"yellow (60deg)", []string{"#ffff00"}, 2},                 // hue = 60
+		{"green (120deg)", []string{"#00ff00"}, 4},                 // hue = 120
+		{"cyan (180deg)", []string{"#00ffff"}, 6},                  // hue = 180
+		{"blue (240deg)", []string{"#0000ff"}, 8},                  // hue = 240
+		{"magenta (300deg)", []string{"#ff00ff"}, 10},              // hue = 300
+		{"pink (330deg)", []string{"#ff0080"}, 11},                 // hue = 330
+		{"dominance order wins: first chromatic swatch", []string{"#0000ff", "#ff0000"}, 8},
+		{"skips achromatic dominant swatch", []string{"#808080", "#ff0000"}, 0},
+		{"skips near-black swatch", []string{"#160505", "#00ff00"}, 4}, // lightness < 0.12
+		{"skips near-white swatch", []string{"#fdf3f2", "#00ff00"}, 4}, // lightness > 0.92
+		{"all gray is neutral", []string{"#111111", "#808080", "#eeeeee"}, NeutralHueGroup},
+		{"empty palette is neutral", nil, NeutralHueGroup},
+		{"invalid hex skipped", []string{"nope", "#00ff00"}, 4},
+		{"only invalid hex is neutral", []string{"zzz"}, NeutralHueGroup},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, HueGroupFromPalette(tt.swatches))
+		})
+	}
+}
+
+func TestHueSortKey(t *testing.T) {
+	g, s := HueSortKey([]string{"#ff0000"})
+	assert.Equal(t, 0, g)
+	assert.InDelta(t, 1.0, s, 0.001) // pure red: HSL saturation 1
+
+	g, s = HueSortKey([]string{"#808080"})
+	assert.Equal(t, NeutralHueGroup, g)
+	assert.Equal(t, 0.0, s)
+
+	// Muted but chromatic red (#b06060: sat ≈ 0.34) still lands in group 0 with its own saturation.
+	g, s = HueSortKey([]string{"#b06060"})
+	assert.Equal(t, 0, g)
+	assert.Greater(t, s, 0.18)
+	assert.Less(t, s, 0.6)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run from `daemon/`: `go test ./internal/cielab/ -run 'TestHueGroupFromPalette|TestHueSortKey' -v`
+Expected: FAIL — `undefined: HueGroupFromPalette`, `undefined: NeutralHueGroup`, `undefined: HueSortKey`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `daemon/internal/cielab/hue.go`:
+
+```go
+package cielab
+
+import "math"
+
+// NeutralHueGroup is the hue group for palettes with no chromatic swatch
+// (grayscale / near-black / near-white images).
+const NeutralHueGroup = 99
+
+// Chromatic swatch thresholds (HSL). A swatch below the saturation floor or
+// outside the lightness band reads as neutral to the eye and is skipped when
+// picking the palette's representative hue.
+const (
+	minChromaticSaturation = 0.18
+	minChromaticLightness  = 0.12
+	maxChromaticLightness  = 0.92
+)
+
+// HueGroupFromPalette returns the 30°-bucket hue group (0-11, red-centered:
+// hue >= 345° or < 15° → 0) of the first chromatic swatch in dominance order,
+// or NeutralHueGroup when no swatch qualifies. Invalid hexes are skipped.
+func HueGroupFromPalette(swatches []string) int {
+	group, _ := HueSortKey(swatches)
+	return group
+}
+
+// HueSortKey returns the hue group plus the winning swatch's HSL saturation,
+// for rainbow ordering (group asc, saturation desc). Neutral → (99, 0).
+func HueSortKey(swatches []string) (int, float64) {
+	for _, hex := range swatches {
+		r, g, b, ok := hexToRGB(hex)
+		if !ok {
+			continue
+		}
+		h, s, l := rgbToHSL(r, g, b)
+		if s < minChromaticSaturation || l < minChromaticLightness || l > maxChromaticLightness {
+			continue
+		}
+		return hueBucket(h), s
+	}
+	return NeutralHueGroup, 0
+}
+
+// hueBucket maps a hue in [0, 360) to a red-centered 30° bucket: shifting by
+// +15° makes [345, 360)∪[0, 15) land in bucket 0.
+func hueBucket(h float64) int {
+	shifted := math.Mod(h+15, 360)
+	return int(shifted/30) % 12
+}
+
+func rgbToHSL(r, g, b uint8) (h, s, l float64) {
+	rf := float64(r) / 255
+	gf := float64(g) / 255
+	bf := float64(b) / 255
+	max := math.Max(rf, math.Max(gf, bf))
+	min := math.Min(rf, math.Min(gf, bf))
+	l = (max + min) / 2
+	d := max - min
+	if d == 0 {
+		return 0, 0, l
+	}
+	if l > 0.5 {
+		s = d / (2 - max - min)
+	} else {
+		s = d / (max + min)
+	}
+	switch max {
+	case rf:
+		h = math.Mod((gf-bf)/d, 6)
+	case gf:
+		h = (bf-rf)/d + 2
+	default:
+		h = (rf-gf)/d + 4
+	}
+	h *= 60
+	if h < 0 {
+		h += 360
+	}
+	return h, s, l
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run from `daemon/`: `go test ./internal/cielab/ -v`
+Expected: PASS (all, including pre-existing cielab tests).
+
+- [ ] **Step 5: gofmt + commit**
+
+```bash
+gofmt -l daemon/internal/cielab/   # expect no output
+git add daemon/internal/cielab/hue.go daemon/internal/cielab/hue_test.go
+git commit -m "feat(daemon): hue-group bucketing from stored palette in cielab"
+```
+
+---
+
+### Task 2: `hue_group` filter + `sort_by=hue` in store and handler (Go) + API contract
+
+**Files:**
+- Modify: `daemon/internal/store/store.go` (ImageQueryOpts, ~line 40-60)
+- Modify: `daemon/internal/store/image_store_impl.go` (GetAll ~line 72-116, helpers at end of file)
+- Modify: `daemon/internal/handler/imageshandler/images.go` (List, ~line 78-120; swagger comments ~line 66-71)
+- Modify: `daemon/API_CONTRACT.md` (GET /images params table, ~line 106-112)
+- Test: `daemon/internal/store/store_test.go` (append; model on `TestImageStore_GetAll_ColorsNear` at line 79 for harness/seeding)
+- Test: `daemon/internal/handler/imageshandler/images_hue_test.go` (create)
+
+**Interfaces:**
+- Consumes (Task 1): `cielab.HueGroupFromPalette(swatches []string) int`, `cielab.HueSortKey(swatches []string) (int, float64)`, `cielab.NeutralHueGroup`.
+- Produces (used by Tasks 3/4 over HTTP): `GET /images?hue_group=<0-11|99>` filter; `GET /images?sort_by=hue&sort_order=asc|desc` rainbow ordering. Invalid `hue_group` → 400 `{"error":"invalid hue_group"}`.
+
+- [ ] **Step 1: Write failing store tests**
+
+Append to `daemon/internal/store/store_test.go` (reuse the file's existing helpers for creating the store and seeding images — read `TestImageStore_GetAll_ColorsNear` first and copy its setup style, seeding images whose `Colors` fields are set as below):
+
+```go
+func TestImageStore_GetAll_HueGroupFilter(t *testing.T) {
+	// Seed three images (same helper style as TestImageStore_GetAll_ColorsNear):
+	//   "red"  → Colors: []string{"#ff0000", "#808080"}
+	//   "blue" → Colors: []string{"#0000ff"}
+	//   "gray" → Colors: []string{"#808080"}
+	// Then:
+	red := 0
+	res, err := is.GetAll(ctx, store.ImageQueryOpts{HueGroup: &red, Page: 1, PerPage: 50})
+	require.NoError(t, err)
+	require.Len(t, res.Data, 1)
+	assert.Equal(t, "red", res.Data[0].Name)
+
+	neutral := 99
+	res, err = is.GetAll(ctx, store.ImageQueryOpts{HueGroup: &neutral, Page: 1, PerPage: 50})
+	require.NoError(t, err)
+	require.Len(t, res.Data, 1)
+	assert.Equal(t, "gray", res.Data[0].Name)
+}
+
+func TestImageStore_GetAll_SortByHue(t *testing.T) {
+	// Seed four images in this insertion order (so imported_at/id order differs from hue order):
+	//   "gray"      → Colors: []string{"#808080"}
+	//   "blue"      → Colors: []string{"#0000ff"}          // group 8, sat 1.0
+	//   "mutedred"  → Colors: []string{"#b06060"}          // group 0, sat ≈ 0.34
+	//   "vividred"  → Colors: []string{"#ff0000"}          // group 0, sat 1.0
+	res, err := is.GetAll(ctx, store.ImageQueryOpts{SortBy: "hue", SortOrder: "asc", Page: 1, PerPage: 50})
+	require.NoError(t, err)
+	require.Len(t, res.Data, 4)
+	// Rainbow asc: group 0 (vivid before muted red), then group 8, neutral last.
+	assert.Equal(t, "vividred", res.Data[0].Name)
+	assert.Equal(t, "mutedred", res.Data[1].Name)
+	assert.Equal(t, "blue", res.Data[2].Name)
+	assert.Equal(t, "gray", res.Data[3].Name)
+
+	// desc reverses group order but neutral stays last.
+	res, err = is.GetAll(ctx, store.ImageQueryOpts{SortBy: "hue", SortOrder: "desc", Page: 1, PerPage: 50})
+	require.NoError(t, err)
+	require.Len(t, res.Data, 4)
+	assert.Equal(t, "blue", res.Data[0].Name)
+	assert.Equal(t, "vividred", res.Data[1].Name)
+	assert.Equal(t, "mutedred", res.Data[2].Name)
+	assert.Equal(t, "gray", res.Data[3].Name)
+}
+```
+
+(The comment lines describe seeding you must write with the file's real helper functions — read the existing tests and use the same creation calls; do not invent new helpers.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+From `daemon/`: `go test ./internal/store/ -run 'HueGroup|SortByHue' -v`
+Expected: FAIL — `unknown field HueGroup in struct literal` (compile error).
+
+- [ ] **Step 3: Implement store support**
+
+In `daemon/internal/store/store.go`, inside `ImageQueryOpts`, after the `SortBy` field update its doc comment and add `HueGroup` after `ColorsNear`:
+
+```go
+	// Sort field: "name", "imported_at", "file_size", or "hue" (rainbow:
+	// hue group asc/desc, neutral last, saturation desc within a group).
+	SortBy string
+```
+
+```go
+	// HueGroup filters to images whose palette's dominant chromatic swatch
+	// falls in this 30° hue bucket (0-11) or cielab.NeutralHueGroup (99).
+	// Computed on the fly from Colors; forces the in-memory filter path.
+	HueGroup *int
+```
+
+In `daemon/internal/store/image_store_impl.go`:
+
+1. Add `"github.com/..."`-style import of the cielab package matching the existing import in the same module (see `filterImagesByColorsNear` which already uses `cielab` — the import already exists; verify).
+
+2. Replace the sort-field block (currently lines ~72-79):
+
+```go
+	sortField := "imported_at"
+	if opts.SortBy != "" && opts.SortBy != "hue" {
+		sortField = opts.SortBy
+	}
+	sortDir := -1
+	if strings.ToLower(opts.SortOrder) == "asc" {
+		sortDir = 1
+	}
+	// Rainbow sort happens in memory; pin the DB pre-sort to newest-first so
+	// in-group ties resolve to imported_at desc via the stable sort below.
+	if opts.SortBy == "hue" {
+		sortDir = -1
+	}
+```
+
+3. Extend the in-memory path condition:
+
+```go
+	if opts.Search != "" || filterRootFolder || len(opts.ColorsNear) > 0 || opts.PaletteSimilarTo != nil || opts.HueGroup != nil || opts.SortBy == "hue" {
+```
+
+4. Inside that branch, after the `PaletteSimilarTo` filter block and before `return Paginate(...)`:
+
+```go
+	if opts.HueGroup != nil {
+		allImages = filterImagesByHueGroup(allImages, *opts.HueGroup)
+	}
+	if opts.SortBy == "hue" {
+		sortImagesByHue(allImages, strings.ToLower(opts.SortOrder) == "desc")
+	}
+```
+
+5. Append helpers at the end of the file, next to `filterImagesByColorsNear`:
+
+```go
+// filterImagesByHueGroup keeps images whose palette maps to the given hue group.
+func filterImagesByHueGroup(images []Image, group int) []Image {
+	filtered := make([]Image, 0, len(images))
+	for _, im := range images {
+		if cielab.HueGroupFromPalette(im.Colors) == group {
+			filtered = append(filtered, im)
+		}
+	}
+	return filtered
+}
+
+// sortImagesByHue orders images rainbow-style: hue group ascending (or
+// descending), neutral group always last, most-saturated first within a
+// group. Stable, so the caller's imported_at pre-sort breaks remaining ties.
+func sortImagesByHue(images []Image, desc bool) {
+	type hueKey struct {
+		group int
+		sat   float64
+	}
+	keys := make(map[int]hueKey, len(images))
+	for _, im := range images {
+		g, s := cielab.HueSortKey(im.Colors)
+		keys[im.ID] = hueKey{group: g, sat: s}
+	}
+	sort.SliceStable(images, func(i, j int) bool {
+		a, b := keys[images[i].ID], keys[images[j].ID]
+		if a.group != b.group {
+			if a.group == cielab.NeutralHueGroup {
+				return false
+			}
+			if b.group == cielab.NeutralHueGroup {
+				return true
+			}
+			if desc {
+				return a.group > b.group
+			}
+			return a.group < b.group
+		}
+		return a.sat > b.sat
+	})
+}
+```
+
+(Add `"sort"` to imports if not present.)
+
+- [ ] **Step 4: Run store tests**
+
+From `daemon/`: `go test ./internal/store/ -v -short`
+Expected: PASS (new tests plus all pre-existing ones).
+
+- [ ] **Step 5: Write failing handler test**
+
+Create `daemon/internal/handler/imageshandler/images_hue_test.go`:
+
+```go
+package imageshandler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseHueGroupParam(t *testing.T) {
+	tests := []struct {
+		raw    string
+		want   int
+		wantOK bool
+	}{
+		{"0", 0, true},
+		{"11", 11, true},
+		{"99", 99, true},
+		{" 5 ", 5, true},
+		{"12", 0, false},
+		{"-1", 0, false},
+		{"98", 0, false},
+		{"abc", 0, false},
+		{"", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			got, ok := parseHueGroupParam(tt.raw)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+```
+
+Run from `daemon/`: `go test ./internal/handler/imageshandler/ -run TestParseHueGroupParam -v`
+Expected: FAIL — `undefined: parseHueGroupParam`.
+
+- [ ] **Step 6: Implement handler support**
+
+In `daemon/internal/handler/imageshandler/images.go`:
+
+1. Next to `parseColorsNearQuery` (~line 825), add:
+
+```go
+// parseHueGroupParam validates the hue_group query value: 0-11 or 99.
+func parseHueGroupParam(raw string) (int, bool) {
+	v, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil {
+		return 0, false
+	}
+	if (v >= 0 && v <= 11) || v == 99 {
+		return v, true
+	}
+	return 0, false
+}
+```
+
+2. In `List`, after the `colors_near` block (~line 101):
+
+```go
+	if hg := strings.TrimSpace(q.Get("hue_group")); hg != "" {
+		v, ok := parseHueGroupParam(hg)
+		if !ok {
+			httpjson.WriteError(w, http.StatusBadRequest, "invalid hue_group")
+			return
+		}
+		opts.HueGroup = &v
+	}
+```
+
+3. Update the swagger comment block above `List` — extend the `sort_by` param description to mention `hue` and add:
+
+```go
+// @Param        hue_group             query     int     false  "Hue group filter: 0-11 (30° buckets, red-centered) or 99 (neutral)"
+```
+
+- [ ] **Step 7: Run handler tests**
+
+From `daemon/`: `go test ./internal/handler/imageshandler/ -v -short`
+Expected: PASS.
+
+- [ ] **Step 8: Update API contract**
+
+In `daemon/API_CONTRACT.md`, GET /images parameter table (~line 106): change the `sort_by` row's allowed values to `name`, `imported_at`, `file_size`, `hue` and add a row after `colors_near`:
+
+```markdown
+| `hue_group`   | int    | —             | Hue group filter: 0–11 (30° buckets, red-centered) or 99 (neutral); computed from the stored palette; forces in-memory filter path |
+```
+
+Also note next to `sort_by`: `hue` = rainbow order (hue group asc/desc, neutral last, saturation desc within group; in-memory).
+
+- [ ] **Step 9: Full daemon unit pass, gofmt, commit**
+
+```bash
+pnpm run test:daemon:unit
+pnpm run gofmt:check
+git add daemon/internal/store/ daemon/internal/handler/imageshandler/ daemon/API_CONTRACT.md
+git commit -m "feat(daemon): hue_group filter and sort_by=hue rainbow ordering on GET /images"
+```
+
+---
+
+### Task 3: Client filter model — types, param mapping, persistence (TS)
+
+**Files:**
+- Modify: `electron/daemon-go-types.ts` (`ImageQueryParams`, ~line 33-47)
+- Modify: `src/types/rendererTypes.ts` (`Filters`, line 22-33)
+- Modify: `src/utils/galleryFilterTokens.ts` (`mapFiltersToImageQueryParams` line 145-180, `galleryHasActiveFilters` line 243-250)
+- Modify: `src/utils/galleryFilterStorage.ts` (`defaultGalleryFilters` line 41-51, `migrateFromLegacyV1` return line 104-113, `normalizeV2` line 123-163)
+- Test: `src/utils/__tests__/galleryFilterTokens.test.ts` (append)
+
+**Interfaces:**
+- Consumes (Task 2 wire format): `hue_group` query param (0–11 | 99), `sort_by: "hue"`.
+- Produces (used by Task 4):
+  - `Filters.hueGroup: number | null` and `Filters.type: "name" | "id" | "hue"` — every construction site of `Filters` compiles with the new field.
+  - `mapFiltersToImageQueryParams` emits `hue_group` and `sort_by`.
+  - `galleryHasActiveFilters` returns true when `hueGroup != null`.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `src/utils/__tests__/galleryFilterTokens.test.ts` (read the file first and reuse its existing helper for building a `Filters` object if one exists; otherwise build literals including ALL current fields plus `hueGroup`):
+
+```ts
+describe("hue group filter mapping", () => {
+  const baseFilters = {
+    order: "desc" as const,
+    type: "id" as const,
+    mediaType: "all" as const,
+    filterTokens: [] as string[],
+    paletteSimilarToId: null,
+    paletteSimilarMaxDeltaE: 18,
+    hueGroup: null as number | null,
+  };
+
+  it("omits hue_group when null", () => {
+    const params = mapFiltersToImageQueryParams(baseFilters);
+    expect(params.hue_group).toBeUndefined();
+  });
+
+  it("emits hue_group when set", () => {
+    const params = mapFiltersToImageQueryParams({ ...baseFilters, hueGroup: 4 });
+    expect(params.hue_group).toBe(4);
+  });
+
+  it("emits neutral group 99", () => {
+    const params = mapFiltersToImageQueryParams({ ...baseFilters, hueGroup: 99 });
+    expect(params.hue_group).toBe(99);
+  });
+
+  it("maps type hue to sort_by hue", () => {
+    const params = mapFiltersToImageQueryParams({ ...baseFilters, type: "hue", order: "asc" });
+    expect(params.sort_by).toBe("hue");
+    expect(params.sort_order).toBe("asc");
+  });
+});
+```
+
+Run: `pnpm vitest run src/utils/__tests__/galleryFilterTokens.test.ts`
+Expected: FAIL (type errors / missing `hue_group`).
+
+- [ ] **Step 2: Implement type + mapping changes**
+
+`electron/daemon-go-types.ts`, in `ImageQueryParams` after `colors_near`:
+
+```ts
+  /** Hue group filter: 0-11 (30° buckets, red-centered) or 99 (neutral). */
+  hue_group?: number;
+```
+
+`src/types/rendererTypes.ts`, in `Filters`:
+
+```ts
+  type: "name" | "id" | "hue";
+```
+
+and after `paletteSimilarMaxDeltaE`:
+
+```ts
+  /** Hue group filter for the swatch strip: 0-11 or 99 (neutral); null = off. */
+  hueGroup: number | null;
+```
+
+`src/utils/galleryFilterTokens.ts`:
+- `mapFiltersToImageQueryParams` `Pick<...>` gains `| "hueGroup"`.
+- `sort_by` line becomes:
+
+```ts
+    sort_by: filters.type === "name" ? "name" : filters.type === "hue" ? "hue" : "imported_at",
+```
+
+- After the `paletteSimilarToId` block:
+
+```ts
+  if (filters.hueGroup != null) {
+    out.hue_group = filters.hueGroup;
+  }
+```
+
+- In `galleryHasActiveFilters`, after the `paletteSimilarToId` check:
+
+```ts
+  if (filters.hueGroup != null) return true;
+```
+
+`src/utils/galleryFilterStorage.ts`:
+- `defaultGalleryFilters()` return gains `hueGroup: null,`.
+- `migrateFromLegacyV1` return gains `hueGroup: null,`.
+- `normalizeV2`: the `type` check becomes `f.type === "name" || f.type === "id" || f.type === "hue" ? f.type : base.type`; add before the return:
+
+```ts
+  const hg = f.hueGroup;
+  const hueGroup =
+    typeof hg === "number" && Number.isInteger(hg) && ((hg >= 0 && hg <= 11) || hg === 99)
+      ? hg
+      : null;
+```
+
+and `hueGroup,` in the returned object.
+
+- [ ] **Step 3: Fix remaining compile errors**
+
+Run: `pnpm exec tsc --noEmit -p tsconfig.json` (or `pnpm run ci:check`'s typecheck step). Any other site constructing a full `Filters` literal must add `hueGroup: null`. Do NOT change behavior anywhere else.
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm vitest run src/utils/__tests__/galleryFilterTokens.test.ts`
+Expected: PASS. Then `pnpm vitest run` (whole suite) — PASS.
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+pnpm run format:check && pnpm run lint:check
+git add electron/daemon-go-types.ts src/types/rendererTypes.ts src/utils/galleryFilterTokens.ts src/utils/galleryFilterStorage.ts src/utils/__tests__/galleryFilterTokens.test.ts
+# plus any files fixed in Step 3
+git commit -m "feat(renderer): hueGroup filter + hue sort in gallery filter model"
+```
+
+---
+
+### Task 4: UI — HueFilterStrip component + Rainbow in the sort cycle
+
+**Files:**
+- Create: `src/components/HueFilterStrip.tsx`
+- Modify: `src/components/Filters.tsx` (SORT_CYCLE lines 51-65, `PartialFilters` lines 28-42, `clearAll` lines 205-222, render block ~line 359-387)
+- Modify: `src/hooks/useFilteredImages.ts` (lines 17-20)
+- Test: `src/components/__tests__/HueFilterStrip.test.tsx` (create; check `src/components/__tests__/` for the existing component-test setup and mimic it — if the directory has no comparable store-driven component test, a pure unit test of the exported `HUE_GROUPS` constant + toggle handler contract is acceptable)
+
+**Interfaces:**
+- Consumes (Task 3): `useImagesStore` `filters.hueGroup`, `setFilters`, `fetchPage`.
+- Produces: `<HueFilterStrip />` default export, rendered inside the filter bar pill group.
+
+- [ ] **Step 1: Write the component**
+
+Create `src/components/HueFilterStrip.tsx`:
+
+```tsx
+import { useImagesStore } from "../stores/images";
+import { cn } from "../utils/cn";
+
+/** 12 hue groups (30° buckets, group k centered at k*30°) + neutral (99). */
+export const HUE_GROUPS: { value: number; label: string; color: string }[] = [
+  ...Array.from({ length: 12 }, (_, k) => ({
+    value: k,
+    label: [
+      "Red",
+      "Orange",
+      "Yellow",
+      "Lime",
+      "Green",
+      "Teal",
+      "Cyan",
+      "Sky",
+      "Blue",
+      "Indigo",
+      "Purple",
+      "Pink",
+    ][k],
+    color: `hsl(${k * 30} 65% 45%)`,
+  })),
+  { value: 99, label: "Neutral", color: "hsl(0 0% 45%)" },
+];
+
+function HueFilterStrip() {
+  const hueGroup = useImagesStore((s) => s.filters.hueGroup);
+
+  const toggle = (value: number) => {
+    const base = useImagesStore.getState().filters;
+    useImagesStore.getState().setFilters({
+      ...base,
+      hueGroup: base.hueGroup === value ? null : value,
+    });
+    useImagesStore.getState().fetchPage(1);
+  };
+
+  return (
+    <div
+      className="flex items-center gap-1 px-1"
+      role="group"
+      aria-label="Filter by dominant color"
+    >
+      {HUE_GROUPS.map(({ value, label, color }) => {
+        const selected = hueGroup === value;
+        return (
+          <button
+            key={value}
+            type="button"
+            title={selected ? `Clear ${label.toLowerCase()} filter` : `Filter by ${label.toLowerCase()}`}
+            aria-label={`Filter by ${label.toLowerCase()}`}
+            aria-pressed={selected}
+            onClick={() => toggle(value)}
+            className={cn(
+              "size-4 shrink-0 cursor-pointer rounded-full border border-base-content/20 transition-transform duration-100",
+              "hover:scale-125 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-primary",
+              selected && "scale-125 ring-2 ring-primary ring-offset-1 ring-offset-base-100",
+            )}
+            style={{ backgroundColor: color }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+export default HueFilterStrip;
+```
+
+- [ ] **Step 2: Wire into the filter bar and sort cycle**
+
+In `src/components/Filters.tsx`:
+
+1. `PartialFilters.type` becomes `"name" | "id" | "hue"` (line 30) — it mirrors `Filters["type"]`.
+
+2. Replace the sort-cycle block (lines 51-65):
+
+```ts
+/* Sort cycles through 5 states: name↑ name↓ id↑ id↓ rainbow */
+type SortState = { type: "name" | "id" | "hue"; order: "asc" | "desc" };
+const SORT_CYCLE: SortState[] = [
+  { type: "name", order: "asc" },
+  { type: "name", order: "desc" },
+  { type: "id", order: "asc" },
+  { type: "id", order: "desc" },
+  { type: "hue", order: "asc" },
+];
+function nextSort(current: SortState): SortState {
+  const idx = SORT_CYCLE.findIndex((s) => s.type === current.type && s.order === current.order);
+  return SORT_CYCLE[(idx + 1) % SORT_CYCLE.length];
+}
+function sortLabel(s: SortState) {
+  if (s.type === "hue") return "Rainbow";
+  return `${s.type === "name" ? "Name" : "ID"} ${s.order === "asc" ? "↑" : "↓"}`;
+}
+```
+
+Note: `nextSort` returns `SORT_CYCLE[0]` on `findIndex === -1`? No — `(-1 + 1) % 5 === 0`, which is already correct fallback behavior; leave as is.
+
+3. Update the sort button `title` (line 375): `"Cycle sort: Name↑ → Name↓ → ID↑ → ID↓ → Rainbow"`.
+
+4. Import and render the strip after the Filters button inside the pill group `<div>` (after line 386, still inside the first group div):
+
+```tsx
+<HueFilterStrip />
+```
+
+with `import HueFilterStrip from "./HueFilterStrip";` at the top.
+
+5. In `clearAll` (line 205), add `hueGroup: null,` to the `setFilters({...})` object so the search-bar clear button also clears the strip.
+
+In `src/hooks/useFilteredImages.ts`, replace lines 17-20:
+
+```ts
+  const sortedImages =
+    filters.type === "id" || filters.type === "hue"
+      ? deferredImages
+      : deferredImages.toSorted((a, b) => b.name.localeCompare(a.name));
+```
+
+(`"hue"` must keep the daemon's rainbow order — client re-sorting by name would destroy it.)
+
+- [ ] **Step 3: Write the test**
+
+Look at `src/components/__tests__/` for the established pattern. Minimum coverage in `src/components/__tests__/HueFilterStrip.test.tsx`:
+
+```tsx
+import { describe, expect, it } from "vitest";
+import { HUE_GROUPS } from "../HueFilterStrip";
+
+describe("HUE_GROUPS", () => {
+  it("has 12 hue buckets plus neutral", () => {
+    expect(HUE_GROUPS).toHaveLength(13);
+    expect(HUE_GROUPS.map((g) => g.value)).toEqual([...Array(12).keys(), 99]);
+  });
+
+  it("centers group k at k*30 degrees", () => {
+    expect(HUE_GROUPS[0].color).toBe("hsl(0 65% 45%)");
+    expect(HUE_GROUPS[8].color).toBe("hsl(240 65% 45%)");
+    expect(HUE_GROUPS[12].color).toBe("hsl(0 0% 45%)");
+  });
+});
+```
+
+If the directory has store-driven render tests (e.g. via @testing-library/react + zustand), additionally cover: clicking a swatch sets `filters.hueGroup`, clicking it again clears to `null`.
+
+- [ ] **Step 4: Run tests + typecheck**
+
+```bash
+pnpm vitest run
+pnpm exec tsc --noEmit -p tsconfig.json
+```
+Expected: PASS, no type errors.
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+pnpm run format:check && pnpm run lint:check
+git add src/components/HueFilterStrip.tsx src/components/Filters.tsx src/hooks/useFilteredImages.ts src/components/__tests__/HueFilterStrip.test.tsx
+git commit -m "feat(renderer): hue filter strip and Rainbow sort in gallery filter bar"
+```
+
+---
+
+### Task 5: Full verification gate
+
+**Files:** none new — fixes only if gates fail.
+
+- [ ] **Step 1: Run the full CI check**
+
+From the worktree root:
+
+```bash
+pnpm run ci:check
+pnpm run test:daemon:unit
+```
+
+Expected: both PASS. If anything fails, fix the specific failure (staying within this feature's files) and re-run.
+
+- [ ] **Step 2: Build daemon binary as a smoke check**
+
+```bash
+make daemon
+```
+
+Expected: builds cleanly.
+
+- [ ] **Step 3: Commit any fixes**
+
+```bash
+git status --porcelain   # commit only if fixes were needed
+```

--- a/docs/superpowers/specs/2026-07-09-hue-filter-rainbow-sort-design.md
+++ b/docs/superpowers/specs/2026-07-09-hue-filter-rainbow-sort-design.md
@@ -1,0 +1,59 @@
+# Hue Filter Strip + Rainbow Sort — Design
+
+**Date:** 2026-07-09
+**Status:** Approved by maintainer
+**Inspiration:** skwd-wall's ColorFilterStrip / color-first sorting, adapted to waypaper-engine's stronger palette data.
+
+## Problem
+
+The gallery already stores a k-means CIELAB palette per image (`Image.colors`, hexes ordered by cluster dominance) and supports `color:` / `near:#hex~ΔE` / palette-similarity filters — but all of it is hidden behind text-token syntax. There is no one-click, discoverable way to browse by color, and no color-aware sort.
+
+## Feature (approved scope)
+
+1. **Hue filter strip**: 13 always-visible swatches in the gallery filter bar — 12 hue groups (30° buckets) + 1 neutral. Click filters the gallery to that group; click again clears. Single-select.
+2. **Rainbow sort**: a 5th state in the existing sort cycle (Name↑ → Name↓ → ID↑ → ID↓ → **Rainbow**) ordering images by hue group ascending (red → pink), most-saturated first within a group, neutrals last.
+
+Out of scope (possible follow-ups): "Color pop" / "Minimalist" sorts, clickable palette swatches in the detail sidebar.
+
+## Architecture decision
+
+The gallery is server-paginated (50/page), so filtering and sorting live in the **daemon**. Hue group is **computed on the fly** from the stored palette via the existing in-memory filter path in `imageStore.GetAll` (same path as `colors_near` / `palette_similar_to`) — no schema change, no migration, works retroactively. Rejected: stored `hue_group` DB field (needs backfill + sync burden, no perf win at collection scale); client-only (breaks across pages).
+
+## Hue bucketing
+
+`HueGroupFromPalette(swatches []string) int` in `daemon/internal/cielab`:
+
+- Walk swatches in stored order (dominance order — most dominant first).
+- Convert hex → RGB → HSL. A swatch is **chromatic** when `saturation ≥ 0.18` and `0.12 ≤ lightness ≤ 0.92`.
+- First chromatic swatch wins: bucket its hue red-centered — hue ≥ 345° or < 15° → group 0 (red); each subsequent 30° → groups 1–11.
+- No chromatic swatch → group **99** (neutral). Invalid hexes are skipped.
+
+This beats skwd-wall's 1×1-average approach: a red-and-blue wallpaper lands in its dominant color's group instead of a fictional purple.
+
+Group centers (for UI swatch colors): group k = hue `k*30°`; neutral = gray.
+
+## API surface
+
+`GET /images` (daemon Unix socket):
+
+- New query param `hue_group` (int: 0–11 or 99; anything else → 400 `invalid hue_group`).
+- `sort_by` accepts new value `hue`. Rainbow order: hue group asc (`sort_order=desc` reverses group order), neutral group always last, saturation of the dominant chromatic swatch desc within a group, `imported_at` desc as final tie-break. When `sort_by=hue`, the DB pre-sort is pinned to `imported_at` desc and real ordering happens in memory.
+- Both trigger the in-memory filter path. Documented in `daemon/API_CONTRACT.md`.
+
+## Client
+
+- `Filters` gains `hueGroup: number | null` (persisted; sanitized on load) and `type` union gains `"hue"`.
+- `mapFiltersToImageQueryParams` emits `hue_group` and `sort_by: "hue"`; `galleryHasActiveFilters` counts an active hue filter; the search-bar "clear all" also clears it.
+- `useFilteredImages` preserves server order for `type === "hue"` (like `"id"`).
+- New `src/components/HueFilterStrip.tsx` rendered in the filter bar's pill group: 13 round swatch buttons, `hsl(k*30 65% 45%)` fills (+ gray neutral), selected swatch gets primary ring + slight scale, `aria-pressed`/`aria-label`s, DaisyUI/theme-variable styling (works in modern + neobrutalist designs; no canvas skew).
+- Sort button label for the new state: **Rainbow**.
+
+## Testing
+
+- Go: `cielab` unit tests (red wrap-around, dominance order, neutral threshold, invalid/empty palettes); store `GetAll` tests for `HueGroup` filtering and `sort_by=hue` ordering (modeled on `TestImageStore_GetAll_ColorsNear`); handler param validation.
+- Vitest: param mapping, storage sanitization, sort-cycle behavior.
+- Gates: `pnpm run ci:check`, `pnpm run test:daemon:unit`.
+
+## Execution
+
+Branch `feat/hue-filter-rainbow-sort` in an isolated worktree (`.worktrees/waypaper-engine-hue`) to avoid conflicts with concurrent documentation work in the main checkout. Subagent-driven development (Sonnet workers), plan at `docs/superpowers/plans/2026-07-09-hue-filter-rainbow-sort.md`.

--- a/electron/daemon-go-types.ts
+++ b/electron/daemon-go-types.ts
@@ -33,7 +33,7 @@ export interface PaginatedResponse<T> {
 export interface ImageQueryParams {
   page?: number;
   per_page?: number;
-  sort_by?: "name" | "imported_at" | "file_size";
+  sort_by?: "name" | "imported_at" | "file_size" | "hue";
   sort_order?: "asc" | "desc";
   media_type?: "image" | "video" | "gif" | "web";
   search?: string;
@@ -45,6 +45,8 @@ export interface ImageQueryParams {
   palette_similar_to?: number;
   /** Inclusive max ΔE vs reference palette; omit to use daemon default (18). */
   palette_max_delta_e?: number;
+  /** Hue group filter: 0-11 (30° buckets, red-centered) or 99 (neutral). */
+  hue_group?: number;
   folder_id?: number | "root";
 }
 

--- a/electron/daemonClient/imagesClient.test.ts
+++ b/electron/daemonClient/imagesClient.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { ImagesClient } from "./imagesClient";
+import type { HttpTransport } from "./httpTransport";
+
+function clientCapturingPath(paths: string[]): ImagesClient {
+  const transport = {
+    request: (_method: string, path: string) => {
+      paths.push(path);
+      return Promise.resolve({ data: [], pagination: null });
+    },
+  } as unknown as HttpTransport;
+  return new ImagesClient(transport);
+}
+
+describe("ImagesClient.getImages query serialization", () => {
+  it("forwards hue_group to the daemon", async () => {
+    const paths: string[] = [];
+    await clientCapturingPath(paths).getImages({ hue_group: 3 });
+    expect(paths[0]).toContain("hue_group=3");
+  });
+
+  it("forwards the neutral hue group (99)", async () => {
+    const paths: string[] = [];
+    await clientCapturingPath(paths).getImages({ hue_group: 99 });
+    expect(paths[0]).toContain("hue_group=99");
+  });
+
+  it("omits hue_group when unset", async () => {
+    const paths: string[] = [];
+    await clientCapturingPath(paths).getImages({ page: 1 });
+    expect(paths[0]).not.toContain("hue_group");
+  });
+});

--- a/electron/daemonClient/imagesClient.ts
+++ b/electron/daemonClient/imagesClient.ts
@@ -28,6 +28,7 @@ export class ImagesClient {
     if (params?.tags) query.set("tags", params.tags);
     if (params?.colors) query.set("colors", params.colors);
     if (params?.colors_near) query.set("colors_near", params.colors_near);
+    if (params?.hue_group !== undefined) query.set("hue_group", String(params.hue_group));
     if (params?.palette_similar_to !== undefined) {
       query.set("palette_similar_to", String(params.palette_similar_to));
     }

--- a/src/components/ColorPickerButtons.tsx
+++ b/src/components/ColorPickerButtons.tsx
@@ -1,0 +1,37 @@
+interface Props {
+  activeNear: boolean;
+  onPickColor: (hex: string) => void;
+}
+
+/** Native color picker; reports a picked hex via onPickColor. */
+function ColorPickerButtons({ activeNear, onPickColor }: Props) {
+  return (
+    <div className="flex items-center gap-1 border-l border-base-content/10 pl-1.5">
+      <label
+        title={activeNear ? "Change color match filter" : "Filter by a specific color"}
+        className="flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-full border border-base-content/20 text-base-content/60 transition-transform duration-100 hover:scale-125 hover:text-base-content focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-primary"
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          className="size-3.5"
+        >
+          <path d="M12 21a9 9 0 1 1 9-9c0 2-1.5 3-3 3h-2a2 2 0 0 0-2 2c0 .5.2 1 .5 1.4.3.4.5.9.5 1.4A2.2 2.2 0 0 1 12 21Z" />
+          <circle cx="7.5" cy="10.5" r=".8" fill="currentColor" />
+          <circle cx="12" cy="7.5" r=".8" fill="currentColor" />
+          <circle cx="16.5" cy="10.5" r=".8" fill="currentColor" />
+        </svg>
+        <input
+          type="color"
+          aria-label="Pick a color to filter by"
+          className="sr-only"
+          onChange={(e) => onPickColor(e.target.value)}
+        />
+      </label>
+    </div>
+  );
+}
+
+export default ColorPickerButtons;

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -14,6 +14,7 @@ import { components as builtinSelectComponents } from "react-select";
 import type { InputProps } from "react-select";
 import useDebounce from "../hooks/useDebounce";
 import { cn } from "../utils/cn";
+import HueFilterStrip from "./HueFilterStrip";
 import type { Filters as FiltersType } from "../types/rendererTypes";
 import { useImagesStore } from "../stores/images";
 import { useShallow } from "zustand/react/shallow";
@@ -48,19 +49,21 @@ const TOKEN_PLACEHOLDER = "Search…  (press / to focus)";
 const PALETTE_SIMILAR_DELTA_MIN = 4;
 const PALETTE_SIMILAR_DELTA_MAX = 50;
 
-/* Sort cycles through 4 states: name↑ name↓ id↑ id↓ */
-type SortState = { type: "name" | "id"; order: "asc" | "desc" };
+/* Sort cycles through 5 states: name↑ name↓ id↑ id↓ rainbow */
+type SortState = { type: "name" | "id" | "hue"; order: "asc" | "desc" };
 const SORT_CYCLE: SortState[] = [
   { type: "name", order: "asc" },
   { type: "name", order: "desc" },
   { type: "id", order: "asc" },
   { type: "id", order: "desc" },
+  { type: "hue", order: "asc" },
 ];
 function nextSort(current: SortState): SortState {
   const idx = SORT_CYCLE.findIndex((s) => s.type === current.type && s.order === current.order);
   return SORT_CYCLE[(idx + 1) % SORT_CYCLE.length];
 }
 function sortLabel(s: SortState) {
+  if (s.type === "hue") return "Rainbow";
   return `${s.type === "name" ? "Name" : "ID"} ${s.order === "asc" ? "↑" : "↓"}`;
 }
 
@@ -215,6 +218,7 @@ function Filters() {
       ...base,
       filterTokens: [],
       paletteSimilarToId: null,
+      hueGroup: null,
     });
     clearGalleryFilterInputHistory();
     setInputHistoryTick((n) => n + 1);
@@ -311,7 +315,7 @@ function Filters() {
   const hasActiveSearch =
     partialFilters.filterTokens.length > 0 || inputHistoryCount > 0 || hasPaletteSimilar;
   const currentSort: SortState = {
-    type: partialFilters.type === "name" ? "name" : "id",
+    type: partialFilters.type,
     order: partialFilters.order,
   };
 
@@ -372,7 +376,7 @@ function Filters() {
             type="button"
             className={`${pillBase} ${pillIdle}`}
             onClick={handleSortCycle}
-            title="Cycle sort: Name↑ → Name↓ → ID↑ → ID↓"
+            title="Cycle sort: Name↑ → Name↓ → ID↑ → ID↓ → Rainbow"
           >
             {sortLabel(currentSort)}
           </button>
@@ -384,6 +388,8 @@ function Filters() {
           >
             Filters
           </button>
+
+          <HueFilterStrip />
         </div>
 
         <div className="w-full min-w-0 md:max-w-4xl md:flex-1">

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -15,11 +15,12 @@ import type { InputProps } from "react-select";
 import useDebounce from "../hooks/useDebounce";
 import { cn } from "../utils/cn";
 import HueFilterStrip from "./HueFilterStrip";
+import ColorPickerButtons from "./ColorPickerButtons";
 import type { Filters as FiltersType } from "../types/rendererTypes";
 import { useImagesStore } from "../stores/images";
 import { useShallow } from "zustand/react/shallow";
 import { useModalStore } from "../stores/modalStore";
-import { mapFiltersToImageQueryParams } from "../utils/galleryFilterTokens";
+import { mapFiltersToImageQueryParams, upsertNearToken } from "../utils/galleryFilterTokens";
 import {
   clearGalleryFilterInputHistory,
   loadGalleryFilterInputHistory,
@@ -48,6 +49,9 @@ const TOKEN_PLACEHOLDER = "Search…  (press / to focus)";
 /** Slider bounds for palette similarity (CIE76 ΔE); daemon still accepts any ≥ 0 on the wire. */
 const PALETTE_SIMILAR_DELTA_MIN = 4;
 const PALETTE_SIMILAR_DELTA_MAX = 50;
+
+/** CIE76 ΔE tolerance for picker-injected near: tokens (~same color family); editable in the token. */
+const NEAR_PICK_DELTA_E = 25;
 
 /* Sort cycles through 5 states: name↑ name↓ id↑ id↓ rainbow */
 type SortState = { type: "name" | "id" | "hue"; order: "asc" | "desc" };
@@ -319,6 +323,19 @@ function Filters() {
     order: partialFilters.order,
   };
 
+  const hasNearToken = partialFilters.filterTokens.some((t) =>
+    t.trim().toLowerCase().startsWith("near:"),
+  );
+
+  const handlePickColor = useCallback((hex: string) => {
+    setPartialFilters((p) => {
+      const filterTokens = upsertNearToken(p.filterTokens, hex, NEAR_PICK_DELTA_E);
+      if (filterTokens === p.filterTokens) return p;
+      prevTokensRef.current = filterTokens;
+      return { ...p, filterTokens };
+    });
+  }, []);
+
   const handleSortCycle = () => {
     const next = nextSort(currentSort);
     setPartialFilters((p) => ({ ...p, type: next.type, order: next.order }));
@@ -390,6 +407,8 @@ function Filters() {
           </button>
 
           <HueFilterStrip />
+
+          <ColorPickerButtons activeNear={hasNearToken} onPickColor={handlePickColor} />
         </div>
 
         <div className="w-full min-w-0 md:max-w-4xl md:flex-1">

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -27,7 +27,7 @@ import {
 
 interface PartialFilters {
   order: "asc" | "desc";
-  type: "name" | "id";
+  type: "name" | "id" | "hue";
   mediaType: "all" | "image" | "video" | "web" | "gif";
   filterTokens: string[];
 }
@@ -311,7 +311,7 @@ function Filters() {
   const hasActiveSearch =
     partialFilters.filterTokens.length > 0 || inputHistoryCount > 0 || hasPaletteSimilar;
   const currentSort: SortState = {
-    type: partialFilters.type,
+    type: partialFilters.type === "name" ? "name" : "id",
     order: partialFilters.order,
   };
 

--- a/src/components/HueFilterStrip.tsx
+++ b/src/components/HueFilterStrip.tsx
@@ -1,0 +1,70 @@
+import { useImagesStore } from "../stores/images";
+import { cn } from "../utils/cn";
+
+/** 12 hue groups (30° buckets, group k centered at k*30°) + neutral (99). */
+export const HUE_GROUPS: { value: number; label: string; color: string }[] = [
+  ...Array.from({ length: 12 }, (_, k) => ({
+    value: k,
+    label: [
+      "Red",
+      "Orange",
+      "Yellow",
+      "Lime",
+      "Green",
+      "Teal",
+      "Cyan",
+      "Sky",
+      "Blue",
+      "Indigo",
+      "Purple",
+      "Pink",
+    ][k],
+    color: `hsl(${k * 30} 65% 45%)`,
+  })),
+  { value: 99, label: "Neutral", color: "hsl(0 0% 45%)" },
+];
+
+function HueFilterStrip() {
+  const hueGroup = useImagesStore((s) => s.filters.hueGroup);
+
+  const toggle = (value: number) => {
+    const base = useImagesStore.getState().filters;
+    useImagesStore.getState().setFilters({
+      ...base,
+      hueGroup: base.hueGroup === value ? null : value,
+    });
+    useImagesStore.getState().fetchPage(1);
+  };
+
+  return (
+    <div
+      className="flex items-center gap-1 px-1"
+      role="group"
+      aria-label="Filter by dominant color"
+    >
+      {HUE_GROUPS.map(({ value, label, color }) => {
+        const selected = hueGroup === value;
+        return (
+          <button
+            key={value}
+            type="button"
+            title={
+              selected ? `Clear ${label.toLowerCase()} filter` : `Filter by ${label.toLowerCase()}`
+            }
+            aria-label={`Filter by ${label.toLowerCase()}`}
+            aria-pressed={selected}
+            onClick={() => toggle(value)}
+            className={cn(
+              "size-4 shrink-0 cursor-pointer rounded-full border border-base-content/20 transition-transform duration-100",
+              "hover:scale-125 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-primary",
+              selected && "scale-125 ring-2 ring-primary ring-offset-1 ring-offset-base-100",
+            )}
+            style={{ backgroundColor: color }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+export default HueFilterStrip;

--- a/src/components/MonitorsModal.tsx
+++ b/src/components/MonitorsModal.tsx
@@ -121,8 +121,8 @@ function Monitors() {
   };
 
   const previewBox = {
-    width: Math.min(window.innerWidth * 0.6, 640),
-    height: Math.min(window.innerHeight * 0.5, 400),
+    width: Math.min(window.innerWidth * 0.7, 920),
+    height: Math.min(window.innerHeight * 0.55, 480),
   };
   const layout = fitMonitorLayout(monitorsList, previewBox);
   const styles: React.CSSProperties = {

--- a/src/components/__tests__/ColorPickerButtons.test.tsx
+++ b/src/components/__tests__/ColorPickerButtons.test.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ColorPickerButtons from "../ColorPickerButtons";
+
+describe("ColorPickerButtons", () => {
+  it("picking a color reports the hex", () => {
+    const onPickColor = vi.fn();
+    render(<ColorPickerButtons activeNear={false} onPickColor={onPickColor} />);
+
+    fireEvent.change(screen.getByLabelText("Pick a color to filter by"), {
+      target: { value: "#3aa7a0" },
+    });
+
+    expect(onPickColor).toHaveBeenCalledWith("#3aa7a0");
+  });
+});

--- a/src/components/__tests__/HueFilterStrip.test.tsx
+++ b/src/components/__tests__/HueFilterStrip.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HUE_GROUPS } from "../HueFilterStrip";
+
+const mockSetFilters = vi.fn();
+const mockFetchPage = vi.fn();
+
+const mockImagesState = {
+  filters: {
+    hueGroup: null as number | null,
+  },
+};
+
+vi.mock("../../stores/images", () => ({
+  useImagesStore: Object.assign(
+    (selector: (s: typeof mockImagesState) => unknown) => selector(mockImagesState),
+    {
+      getState: () => ({
+        fetchPage: mockFetchPage,
+        filters: mockImagesState.filters,
+        setFilters: mockSetFilters,
+      }),
+    },
+  ),
+}));
+
+import HueFilterStrip from "../HueFilterStrip";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockImagesState.filters.hueGroup = null;
+});
+
+describe("HUE_GROUPS", () => {
+  it("has 12 hue buckets plus neutral", () => {
+    expect(HUE_GROUPS).toHaveLength(13);
+    expect(HUE_GROUPS.map((g) => g.value)).toEqual([...Array(12).keys(), 99]);
+  });
+
+  it("centers group k at k*30 degrees", () => {
+    expect(HUE_GROUPS[0].color).toBe("hsl(0 65% 45%)");
+    expect(HUE_GROUPS[8].color).toBe("hsl(240 65% 45%)");
+    expect(HUE_GROUPS[12].color).toBe("hsl(0 0% 45%)");
+  });
+});
+
+describe("HueFilterStrip", () => {
+  it("clicking a swatch sets filters.hueGroup and fetches page 1", async () => {
+    const user = userEvent.setup();
+    render(<HueFilterStrip />);
+
+    await user.click(screen.getByRole("button", { name: "Filter by red" }));
+
+    expect(mockSetFilters).toHaveBeenCalledWith(expect.objectContaining({ hueGroup: 0 }));
+    expect(mockFetchPage).toHaveBeenCalledWith(1);
+  });
+
+  it("clicking the selected swatch again clears the filter to null", async () => {
+    const user = userEvent.setup();
+    mockImagesState.filters.hueGroup = 0;
+    render(<HueFilterStrip />);
+
+    await user.click(screen.getByRole("button", { name: "Filter by red" }));
+
+    expect(mockSetFilters).toHaveBeenCalledWith(expect.objectContaining({ hueGroup: null }));
+  });
+});

--- a/src/components/__tests__/MonitorsModal.test.tsx
+++ b/src/components/__tests__/MonitorsModal.test.tsx
@@ -136,7 +136,7 @@ describe("MonitorsModal", () => {
   });
 
   it("scales stacked monitors to fit the preview box (issue #225)", () => {
-    // 1600x900 window → preview box of 640x400 (min(60vw, 640) x min(50vh, 400))
+    // 1600x900 window → preview box of 920x480 (min(70vw, 920) x min(55vh, 480))
     const originalWidth = window.innerWidth;
     const originalHeight = window.innerHeight;
     Object.defineProperty(window, "innerWidth", { value: 1600, configurable: true });
@@ -150,10 +150,10 @@ describe("MonitorsModal", () => {
 
       render(<Monitors />);
 
-      const scale = 400 / 2880;
+      const scale = 480 / 2880;
       const layout = screen.getByTestId("monitor-layout");
       expect(parseFloat(layout.style.width)).toBeCloseTo(2560 * scale, 1);
-      expect(parseFloat(layout.style.height)).toBeCloseTo(400, 1);
+      expect(parseFloat(layout.style.height)).toBeCloseTo(480, 1);
 
       const bottomWrapper = screen.getByTestId("monitor-eDP-1").parentElement as HTMLElement;
       expect(parseFloat(bottomWrapper.style.top)).toBeCloseTo(1440 * scale, 1);

--- a/src/hooks/useFilteredImages.ts
+++ b/src/hooks/useFilteredImages.ts
@@ -15,7 +15,7 @@ export function useFilteredImages() {
   const deferredImages = useDeferredValue(imagesArray);
 
   const sortedImages =
-    filters.type === "id"
+    filters.type === "id" || filters.type === "hue"
       ? deferredImages
       : deferredImages.toSorted((a, b) => b.name.localeCompare(a.name));
 

--- a/src/types/rendererTypes.ts
+++ b/src/types/rendererTypes.ts
@@ -21,7 +21,7 @@ export type monitorSelectType = MonitorMode;
 
 export interface Filters {
   order: "asc" | "desc";
-  type: "name" | "id";
+  type: "name" | "id" | "hue";
   mediaType: "all" | "image" | "video" | "web" | "gif";
   /** Token query: tag:, type:, ext:, color:, near:#hex~ΔE, q:, or plain text */
   filterTokens: string[];
@@ -30,6 +30,8 @@ export interface Filters {
   paletteSimilarToId: number | null;
   /** Inclusive max ΔE for palette similarity (sent as palette_max_delta_e). */
   paletteSimilarMaxDeltaE: number;
+  /** Hue group filter for the swatch strip: 0-11 or 99 (neutral); null = off. */
+  hueGroup: number | null;
 }
 
 export interface advancedFilters {

--- a/src/utils/__tests__/galleryFilterTokens.test.ts
+++ b/src/utils/__tests__/galleryFilterTokens.test.ts
@@ -8,6 +8,7 @@ import {
   clientImageMatchesFilters,
   hasClientSideGalleryFilters,
   galleryHasActiveFilters,
+  upsertNearToken,
 } from "../galleryFilterTokens";
 import type { rendererImage } from "../../types/rendererTypes";
 import { defaultGalleryFilters } from "../galleryFilterStorage";
@@ -297,5 +298,29 @@ describe("hue group filter mapping", () => {
     const params = mapFiltersToImageQueryParams({ ...baseFilters, type: "hue", order: "asc" });
     expect(params.sort_by).toBe("hue");
     expect(params.sort_order).toBe("asc");
+  });
+});
+
+describe("upsertNearToken", () => {
+  it("appends a normalized near: token", () => {
+    expect(upsertNearToken(["tag:nature"], "#3AA7A0", 25)).toEqual([
+      "tag:nature",
+      "near:#3aa7a0~25",
+    ]);
+  });
+
+  it("expands #rgb shorthand", () => {
+    expect(upsertNearToken([], "#f80", 25)).toEqual(["near:#ff8800~25"]);
+  });
+
+  it("replaces existing near: tokens instead of accumulating", () => {
+    expect(
+      upsertNearToken(["near:#ff0000~10", "tag:sky", "near:#00ff00~5"], "#0000ff", 25),
+    ).toEqual(["tag:sky", "near:#0000ff~25"]);
+  });
+
+  it("returns tokens unchanged for an invalid hex", () => {
+    const tokens = ["tag:sky"];
+    expect(upsertNearToken(tokens, "notahex", 25)).toBe(tokens);
   });
 });

--- a/src/utils/__tests__/galleryFilterTokens.test.ts
+++ b/src/utils/__tests__/galleryFilterTokens.test.ts
@@ -107,6 +107,7 @@ describe("mapFiltersToImageQueryParams", () => {
   const baseFilterFields = {
     paletteSimilarToId: null,
     paletteSimilarMaxDeltaE: 18,
+    hueGroup: null,
   } as const;
 
   it("maps sort and combined API fields", () => {
@@ -263,5 +264,38 @@ describe("galleryHasActiveFilters", () => {
     ).toBe(true);
     expect(galleryHasActiveFilters({ ...base, paletteSimilarToId: 7 })).toBe(true);
     expect(galleryHasActiveFilters(base)).toBe(false);
+  });
+});
+
+describe("hue group filter mapping", () => {
+  const baseFilters = {
+    order: "desc" as const,
+    type: "id" as const,
+    mediaType: "all" as const,
+    filterTokens: [] as string[],
+    paletteSimilarToId: null,
+    paletteSimilarMaxDeltaE: 18,
+    hueGroup: null as number | null,
+  };
+
+  it("omits hue_group when null", () => {
+    const params = mapFiltersToImageQueryParams(baseFilters);
+    expect(params.hue_group).toBeUndefined();
+  });
+
+  it("emits hue_group when set", () => {
+    const params = mapFiltersToImageQueryParams({ ...baseFilters, hueGroup: 4 });
+    expect(params.hue_group).toBe(4);
+  });
+
+  it("emits neutral group 99", () => {
+    const params = mapFiltersToImageQueryParams({ ...baseFilters, hueGroup: 99 });
+    expect(params.hue_group).toBe(99);
+  });
+
+  it("maps type hue to sort_by hue", () => {
+    const params = mapFiltersToImageQueryParams({ ...baseFilters, type: "hue", order: "asc" });
+    expect(params.sort_by).toBe("hue");
+    expect(params.sort_order).toBe("asc");
   });
 });

--- a/src/utils/galleryFilterStorage.ts
+++ b/src/utils/galleryFilterStorage.ts
@@ -49,6 +49,7 @@ export function defaultGalleryFilters(): Filters {
     advancedFilters: defaultAdvancedFilters(),
     paletteSimilarToId: null,
     paletteSimilarMaxDeltaE: 18,
+    hueGroup: null,
   };
 }
 
@@ -109,6 +110,7 @@ function migrateFromLegacyV1(raw: LegacyFiltersV1): Filters {
     advancedFilters: { resolution },
     paletteSimilarToId: null,
     paletteSimilarMaxDeltaE: 18,
+    hueGroup: null,
   };
 }
 
@@ -130,9 +132,14 @@ function normalizeV2(o: Record<string, unknown>): Filters {
     const m = Number(f.paletteSimilarMaxDeltaE);
     return Number.isFinite(m) && m > 0 ? m : base.paletteSimilarMaxDeltaE;
   })();
+  const hg = f.hueGroup;
+  const hueGroup =
+    typeof hg === "number" && Number.isInteger(hg) && ((hg >= 0 && hg <= 11) || hg === 99)
+      ? hg
+      : null;
   return {
     order: f.order === "asc" || f.order === "desc" ? f.order : base.order,
-    type: f.type === "name" || f.type === "id" ? f.type : base.type,
+    type: f.type === "name" || f.type === "id" || f.type === "hue" ? f.type : base.type,
     mediaType:
       f.mediaType === "all" ||
       f.mediaType === "image" ||
@@ -159,6 +166,7 @@ function normalizeV2(o: Record<string, unknown>): Filters {
     },
     paletteSimilarToId,
     paletteSimilarMaxDeltaE,
+    hueGroup,
   };
 }
 

--- a/src/utils/galleryFilterTokens.ts
+++ b/src/utils/galleryFilterTokens.ts
@@ -54,6 +54,17 @@ export function parseNearColorSpec(rest: string): ColorNearSpec | null {
   return { hex, maxDeltaE: n };
 }
 
+/**
+ * Replaces any existing near: tokens with a single `near:#hex~maxDeltaE`.
+ * Returns tokens unchanged when hex is invalid.
+ */
+export function upsertNearToken(tokens: string[], hex: string, maxDeltaE: number): string[] {
+  const normalized = normalizeColorHex(hex);
+  if (normalized == null) return tokens;
+  const kept = tokens.filter((t) => splitPrefix(t.trim())?.key !== "near");
+  return [...kept, `near:${normalized}~${maxDeltaE}`];
+}
+
 export function parseGalleryFilterTokens(tokens: string[]): ParsedGalleryTokens {
   const searchParts: string[] = [];
   const tags: string[] = [];

--- a/src/utils/galleryFilterTokens.ts
+++ b/src/utils/galleryFilterTokens.ts
@@ -151,6 +151,7 @@ export function mapFiltersToImageQueryParams(
     | "filterTokens"
     | "paletteSimilarToId"
     | "paletteSimilarMaxDeltaE"
+    | "hueGroup"
   >,
 ): Partial<ImageQueryParams> {
   const parsed = parseGalleryFilterTokens(filters.filterTokens);
@@ -162,7 +163,7 @@ export function mapFiltersToImageQueryParams(
       : undefined;
 
   const out: Partial<ImageQueryParams> = {
-    sort_by: filters.type === "name" ? "name" : "imported_at",
+    sort_by: filters.type === "name" ? "name" : filters.type === "hue" ? "hue" : "imported_at",
     sort_order: filters.order,
     media_type: mt,
     search,
@@ -174,6 +175,10 @@ export function mapFiltersToImageQueryParams(
   if (filters.paletteSimilarToId != null) {
     out.palette_similar_to = filters.paletteSimilarToId;
     out.palette_max_delta_e = filters.paletteSimilarMaxDeltaE;
+  }
+
+  if (filters.hueGroup != null) {
+    out.hue_group = filters.hueGroup;
   }
 
   return out;
@@ -244,6 +249,7 @@ export function galleryHasActiveFilters(filters: Filters): boolean {
   if (filters.filterTokens.length > 0) return true;
   if (filters.mediaType !== "all") return true;
   if (filters.paletteSimilarToId != null) return true;
+  if (filters.hueGroup != null) return true;
   if (filters.advancedFilters.resolution.constraint !== "all") return true;
   const parsed = parseGalleryFilterTokens(filters.filterTokens);
   return hasClientSideGalleryFilters(parsed, filters.mediaType, filters.advancedFilters.resolution);


### PR DESCRIPTION
Adds a 13-swatch hue filter strip and a Rainbow sort mode to the gallery, computed daemon-side from each image's stored k-means palette (new `hue_group` param and `sort_by=hue` on GET /images), plus a native color picker that injects perceptual `near:#hex~25` match tokens. Also enlarges the Choose Display monitor previews.