### PR TITLE
fix(walqt): wait for outputs before reporting ready

### DIFF
--- a/daemon/internal/backend/walqt/startup_outputs_test.go
+++ b/daemon/internal/backend/walqt/startup_outputs_test.go
@@ -1,0 +1,119 @@
+package walqt
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// wal-qt answers GET /health as soon as its HTTP server binds, which happens
+// well before LayerShellQt has created the per-output surfaces. Applying a
+// wallpaper in that window is accepted and recorded by wal-qt but never
+// painted, leaving a black desktop until something applies again. Initialize
+// must therefore keep waiting until wal-qt reports at least one output.
+func TestInitialize_WaitsForOutputsBeforeReportingReady(t *testing.T) {
+	tmpDir := t.TempDir()
+	dummyBin := tmpDir + "/wal-qt-host"
+	require.NoError(t, os.WriteFile(dummyBin, []byte("#!/bin/sh\nsleep 30\n"), 0o755))
+	t.Setenv("PATH", tmpDir+":"+os.Getenv("PATH"))
+
+	var statusCalls int64
+	// Report zero outputs for the first two status polls, then two monitors —
+	// mirroring wal-qt's real startup, where outputs appear after /health is up.
+	const zeroOutputPolls = 2
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok": true, "service": "wal-qt", "api_version": "0",
+			})
+		case "/wallpaper/status":
+			n := atomic.AddInt64(&statusCalls, 1)
+			count := 2
+			if n <= zeroOutputPolls {
+				count = 0
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok": true, "api_version": "0",
+				"status": map[string]any{"monitor_count": count},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	b := &WalQt{
+		makeClient: func(_ *Config) (*controlClient, error) {
+			return newTestControlClient(srv, "wal-qt", "0"), nil
+		},
+	}
+
+	require.NoError(t, b.Initialize(context.Background()))
+
+	// Initialize must not report ready while wal-qt still has zero outputs.
+	assert.Greater(t, atomic.LoadInt64(&statusCalls), int64(zeroOutputPolls),
+		"Initialize returned before wal-qt reported any outputs")
+}
+
+// Same guarantee on the spawn path: this is the sequence that actually left the
+// desktop black at login — the daemon spawned wal-qt, saw /health go green
+// ~450ms later, and applied the restore snapshot before any output existed.
+func TestInitialize_WaitsForOutputsAfterSpawningChild(t *testing.T) {
+	tmpDir := t.TempDir()
+	dummyBin := tmpDir + "/wal-qt-host"
+	require.NoError(t, os.WriteFile(dummyBin, []byte("#!/bin/sh\nsleep 30\n"), 0o755))
+	t.Setenv("PATH", tmpDir+":"+os.Getenv("PATH"))
+
+	var healthCalls, statusCalls int64
+	// Health is refused until the child "boots", forcing the spawn path.
+	const unhealthyPolls = 1
+	const zeroOutputPolls = 2
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			if atomic.AddInt64(&healthCalls, 1) <= unhealthyPolls {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok": true, "service": "wal-qt", "api_version": "0",
+			})
+		case "/wallpaper/status":
+			n := atomic.AddInt64(&statusCalls, 1)
+			count := 2
+			if n <= zeroOutputPolls {
+				count = 0
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok": true, "api_version": "0",
+				"status": map[string]any{"monitor_count": count},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	b := &WalQt{
+		makeClient: func(_ *Config) (*controlClient, error) {
+			return newTestControlClient(srv, "wal-qt", "0"), nil
+		},
+	}
+
+	require.NoError(t, b.Initialize(context.Background()))
+
+	require.Greater(t, atomic.LoadInt64(&healthCalls), int64(unhealthyPolls),
+		"expected the spawn path to be exercised")
+	assert.Greater(t, atomic.LoadInt64(&statusCalls), int64(zeroOutputPolls),
+		"Initialize returned before wal-qt reported any outputs")
+}

--- a/daemon/internal/backend/walqt/walqt.go
+++ b/daemon/internal/backend/walqt/walqt.go
@@ -179,6 +179,7 @@ func (w *WalQt) initializeImpl(ctx context.Context) error {
 
 	if initialErr == nil {
 		slog.Info("wal-qt already running")
+		w.pollOutputsUntilReady(ctx, client, cfg)
 		w.syncParallaxDriver(w.loadConfigFromViper(), true)
 		return nil
 	}
@@ -233,6 +234,7 @@ func (w *WalQt) initializeImpl(ctx context.Context) error {
 	if err := w.pollHealthUntilReady(ctx, client, cfg); err != nil {
 		return err
 	}
+	w.pollOutputsUntilReady(ctx, client, cfg)
 	slog.Info("wal-qt ready after spawn")
 	w.allowManagedChildRespawn.Store(true)
 	w.syncParallaxDriver(w.loadConfigFromViper(), true)
@@ -303,6 +305,48 @@ func (w *WalQt) pollHealthUntilReady(ctx context.Context, client *controlClient,
 		"wal-qt: unavailable after %d health poll attempts (~50s, last error: %w). "+
 			"Ensure the binary runs on Wayland and "+viperBackendKey+".socket_path matches the child",
 		attempts, lastErr,
+	)
+}
+
+// outputsReadyTimeout bounds the wait for wal-qt to register its outputs.
+const outputsReadyTimeout = 10 * time.Second
+
+// pollOutputsUntilReady blocks until wal-qt reports at least one output.
+//
+// GET /health goes green as soon as wal-qt's control server binds, which is
+// well before LayerShellQt has created the per-output surfaces. A wallpaper
+// applied in that window is accepted and recorded by wal-qt but never painted,
+// so the desktop stays black until something applies again — which is what made
+// the wallpaper vanish on every cold boot.
+//
+// Zero outputs is legitimate (every monitor disabled/off), so a timeout only
+// warns: blocking startup forever would be worse than a missing wallpaper.
+func (w *WalQt) pollOutputsUntilReady(ctx context.Context, client *controlClient, cfg *Config) {
+	deadline := time.Now().Add(outputsReadyTimeout)
+	delay := 100 * time.Millisecond
+	const maxDelay = time.Second
+	attempts := 0
+
+	for time.Now().Before(deadline) {
+		attempts++
+		statusCtx, cancel := context.WithTimeout(ctx, time.Duration(cfg.RequestTimeoutMS)*time.Millisecond)
+		st, err := client.status(statusCtx)
+		cancel()
+		if err == nil && st.Status.MonitorCount > 0 {
+			slog.Info("wal-qt outputs ready", "monitors", st.Status.MonitorCount, "poll_attempts", attempts)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(delay):
+		}
+		delay = min(delay*2, maxDelay)
+	}
+
+	slog.Warn("wal-qt reported no outputs before timeout; applying anyway",
+		"timeout", outputsReadyTimeout,
+		"poll_attempts", attempts,
 	)
 }
 

--- a/daemon/internal/backend/walqt/walqt.go
+++ b/daemon/internal/backend/walqt/walqt.go
@@ -311,16 +311,6 @@ func (w *WalQt) pollHealthUntilReady(ctx context.Context, client *controlClient,
 // outputsReadyTimeout bounds the wait for wal-qt to register its outputs.
 const outputsReadyTimeout = 10 * time.Second
 
-// pollOutputsUntilReady blocks until wal-qt reports at least one output.
-//
-// GET /health goes green as soon as wal-qt's control server binds, which is
-// well before LayerShellQt has created the per-output surfaces. A wallpaper
-// applied in that window is accepted and recorded by wal-qt but never painted,
-// so the desktop stays black until something applies again — which is what made
-// the wallpaper vanish on every cold boot.
-//
-// Zero outputs is legitimate (every monitor disabled/off), so a timeout only
-// warns: blocking startup forever would be worse than a missing wallpaper.
 func (w *WalQt) pollOutputsUntilReady(ctx context.Context, client *controlClient, cfg *Config) {
 	deadline := time.Now().Add(outputsReadyTimeout)
 	delay := 100 * time.Millisecond


### PR DESCRIPTION
## Problem

Wallpaper was missing after every cold boot — a black desktop, even though the daemon and `wal-qt` both reported success.

`GET /health` goes green as soon as wal-qt's control server binds, which happens well before LayerShellQt creates the per-output surfaces. `Initialize` treated that as ready, so the restore snapshot was applied ~450ms after spawn while wal-qt still had **zero outputs**:

```
20:13:46.003  starting wal-qt
20:13:46.455  wal-qt health ok (3 polls)
20:13:46.457  Apply -> nil (success)
20:13:46.458  wallpaper restore complete restored:2 skipped:0
```

wal-qt accepted the load and recorded it (`current_target` set, `visible: true`) but never painted it. Nothing replays the recorded target once outputs appear, so the desktop stayed black until some later apply happened to land.

Confirmed on a live session: re-applying the *identical* image rendered it immediately.

## Fix

`Initialize` now polls `GET /wallpaper/status` until wal-qt reports at least one output, on both the already-running and post-spawn paths.

Zero outputs is legitimate (every monitor disabled/off), so the wait is bounded at 10s and only warns on timeout — blocking startup forever would be worse than a missing wallpaper.

## Tests

Written test-first, both verified failing before the fix:

- `TestInitialize_WaitsForOutputsBeforeReportingReady` — already-running path
- `TestInitialize_WaitsForOutputsAfterSpawningChild` — spawn path, the sequence that actually caused the bug

Fake control server reports zero outputs for the first polls, then two.

`go test -short ./...` green; build, `gofmt`, `go vet` clean.