### PR TITLE
fix(wallpaper): re-stamp monitor state backend on restore

### DIFF
--- a/daemon/internal/wallpaper/restore.go
+++ b/daemon/internal/wallpaper/restore.go
@@ -185,6 +185,12 @@ func Restore(
 		return
 	}
 
+	persisted := make(map[string]store.MonitorState, len(states))
+	for _, st := range states {
+		persisted[st.MonitorName] = st
+	}
+	activeName := activeBackend.Name()
+
 	// Update in-memory current wallpaper state for each restored output.
 	for _, out := range snap.Outputs {
 		entry := store.ImageHistoryEntry{
@@ -192,9 +198,25 @@ func Restore(
 			Mode:     string(backend.ModeClone), // best-effort; mode not tracked per-output here
 			SetAt:    time.Now(),
 			Source:   store.HistorySource{Type: "restore"},
-			Backend:  activeBackend.Name(),
+			Backend:  activeName,
 		}
 		stateStore.SetCurrentWallpaper(out.Monitor.Name, entry)
+
+		// Re-stamp the persisted row with the backend that actually applied it.
+		// Auto-mode switches backends per playlist tick without persisting the
+		// choice, so rows routinely name a backend the daemon did not boot into.
+		// GET /wallpaper/current drops rows whose backend != the active one,
+		// which otherwise leaves the UI with no current wallpaper after a restore.
+		// SetAt is left alone — restoring is not a new wallpaper change.
+		st, ok := persisted[out.Monitor.Name]
+		if !ok || st.Backend == activeName {
+			continue
+		}
+		st.Backend = activeName
+		if err := monitorStateStore.Set(ctx, st); err != nil {
+			slog.Warn("restore: failed to refresh persisted backend",
+				"monitor", st.MonitorName, "backend", activeName, "error", err)
+		}
 	}
 
 	slog.Info("wallpaper restore complete", "restored", len(snap.Outputs), "skipped", len(skips))

--- a/daemon/internal/wallpaper/restore_test.go
+++ b/daemon/internal/wallpaper/restore_test.go
@@ -151,3 +151,59 @@ func TestRestore_SkipsDisconnectedMonitors(t *testing.T) {
 	require.Len(t, gotSnap.Outputs, 1)
 	assert.Equal(t, "A", gotSnap.Outputs[0].Monitor.Name)
 }
+
+// TestRestore_RewritesMonitorStateBackend verifies that restoring through the
+// active backend refreshes the persisted backend name on each monitor row.
+//
+// Auto-mode switches backends per playlist tick without persisting the choice,
+// so rows routinely record a different backend than the one the daemon boots
+// into. GET /wallpaper/current drops rows whose backend != the active backend,
+// which left the UI with no current wallpaper (blank monitor-modal thumbnail)
+// until the user set an image by hand.
+func TestRestore_RewritesMonitorStateBackend(t *testing.T) {
+	mockBe := &testutil.MockBackend{
+		NameFn: func() string { return "wal-qt" },
+		CapabilitiesFn: func() backend.Capabilities {
+			return backend.Capabilities{
+				ContentKinds: []backend.ContentKind{backend.KindStaticImage},
+			}
+		},
+		ApplyFn: func(context.Context, backend.Snapshot) error { return nil },
+	}
+	reg := &testutil.MockRegistry{ActiveFn: func() backend.Backend { return mockBe }}
+
+	saved := map[string]store.MonitorState{}
+	mss := &testutil.MockMonitorStateStore{
+		GetAllFn: func(context.Context) ([]store.MonitorState, error) {
+			// Rows left behind by a previous session that ended on awww.
+			return []store.MonitorState{
+				{MonitorName: "A", ImageID: 1, ImagePath: "/a.png", Mode: string(monitor.ModeClone), Backend: "awww"},
+				{MonitorName: "B", ImageID: 1, ImagePath: "/a.png", Mode: string(monitor.ModeClone), Backend: "awww"},
+			}, nil
+		},
+		SetFn: func(_ context.Context, st store.MonitorState) error {
+			saved[st.MonitorName] = st
+			return nil
+		},
+	}
+	mm := &testutil.MockMonitorManager{
+		GetMonitorsFn: func(context.Context) ([]monitor.Monitor, error) {
+			return []monitor.Monitor{{Name: "A"}, {Name: "B"}}, nil
+		},
+	}
+	imgStore := &testutil.MockImageStore{
+		GetByIDFn: func(_ context.Context, id int) (*store.Image, error) {
+			return &store.Image{ID: id, MediaType: "image", Path: "/dev/null"}, nil
+		},
+	}
+
+	wallpaper.Restore(context.Background(), mss, &testutil.MockStateStore{}, reg, &testutil.MockConfigManager{}, mm, imgStore, nil, nil)
+
+	require.Len(t, saved, 2, "both restored monitors should be persisted")
+	for _, name := range []string{"A", "B"} {
+		assert.Equal(t, "wal-qt", saved[name].Backend,
+			"monitor %s should record the backend that applied the wallpaper", name)
+		// The rest of the row must survive the rewrite.
+		assert.Equal(t, 1, saved[name].ImageID, "monitor %s image should be preserved", name)
+	}
+}


### PR DESCRIPTION
## Problem

On a fresh start the monitor modal showed no wallpaper thumbnail. Setting any image with the app open made it appear — the known workaround.

`GET /wallpaper/current` reads persisted `monitor_state` rows and drops any whose backend differs from the active one (`wallpaper_current_response.go:51`):

```go
if st.Backend != activeBackend { continue }
```

Auto-mode switches backends per playlist tick with `PersistConfig: false` (deliberately, to avoid rewriting `config.toml` every tick), so rows record whichever backend actually applied — while startup always initializes the *configured* backend. Any mismatch blanks the UI.

Observed live: both rows read `backend: "awww"` while the daemon booted into `wal-qt`, so `/wallpaper/current` returned an empty payload even though `Restore` had applied those exact rows (`restored:2 skipped:0`).

## Fix

`Restore` now re-stamps each persisted row with the backend that actually applied it, restoring the row invariant documented on `MonitorState.Backend` ("the name of the backend that applied the wallpaper").

`SetAt` is deliberately left alone — restoring is not a new wallpaper change, and rewriting it would reorder the primary-monitor pick in `pickPrimaryMonitorState`.

## Tests

Written test-first, verified failing before the fix:

- `TestRestore_RewritesMonitorStateBackend` — stale `awww` rows restored through a `wal-qt` active backend must end up stamped `wal-qt`, with the rest of the row preserved

`go test -short ./...` green; build, `gofmt`, `go vet` clean.

## Note

Independent of #237, which fixes the black-desktop-at-boot race. The two compound: this bug blanked the "current wallpaper" in the UI, which is what made a running playlist look stopped.