### PR TITLE
refactor(daemon)!: target monitors explicitly instead of "*"

### DIFF
--- a/daemon/API_CONTRACT.md
+++ b/daemon/API_CONTRACT.md
@@ -590,17 +590,20 @@ Start playing a playlist.
 
 ```json
 {
-  "monitor": {
-    "id": "*",
-    "mode": "individual"
-  }
+  "monitors": ["DP-1", "DP-2"],
+  "extend": false
 }
 ```
 
-| Field          | Type   | Default        | Description                     |
-| -------------- | ------ | -------------- | ------------------------------- |
-| `monitor.id`   | string | `"*"` (all)    | Target monitor or `"*"` for all |
-| `monitor.mode` | string | `"individual"` | `individual`, `clone`, `extend` |
+| Field      | Type     | Default              | Description                                                      |
+| ---------- | -------- | -------------------- | ---------------------------------------------------------------- |
+| `monitors` | string[] | all connected        | Declared monitor names; disconnected names are accepted and kept |
+| `extend`   | bool     | `false`              | `true` slices one image across the group, `false` clones it      |
+
+The declared set is stored verbatim and never rewritten from what is connected.
+Names that are not connected stay in the set and are applied when they return.
+
+**Response** `400`: none of the declared monitors is connected.
 
 **Response** `200`:
 
@@ -655,13 +658,17 @@ Get all currently running playlists as active instances.
     "next_image_id": 1,
     "total_images": 3,
     "paused": false,
-    "mode": "clone",
     "started_at": "2026-02-15T14:30:00Z",
     "next_change_at": "2026-02-15T14:35:00Z",
-    "monitors": ["DP-1", "HDMI-A-1"]
+    "monitors": ["DP-1", "HDMI-A-1"],
+    "applied_to": ["DP-1"],
+    "extend": false
   }
 ]
 ```
+
+`monitors` is the declared set, `applied_to` the subset currently connected and
+actually applied.
 
 See [ActivePlaylistResponse model](#activeplaylistresponse).
 
@@ -1046,7 +1053,7 @@ Persistent streaming connection. Each event has:
 
 | Event                    | Data                                                   |
 | ------------------------ | ------------------------------------------------------ |
-| `playlist_started`       | `{"playlist_id": 1, "monitor": "DP-1"}`                |
+| `playlist_started`       | `{"playlist_id": 1, "playlist_name": "Evening rotation", "monitors": ["DP-1", "DP-2"], "applied_to": ["DP-1"], "extend": false}` |
 | `playlist_stopped`       | `{"playlist_id": 1, "monitor": "DP-1"}`                |
 | `playlist_paused`        | `{"playlist_id": 1, "monitor": "DP-1"}`                |
 | `playlist_resumed`       | `{"playlist_id": 1, "monitor": "DP-1"}`                |
@@ -1218,13 +1225,16 @@ Returned by `GET /playlists/active/{monitor}` (single instance) and by `GET /pla
   "next_image_id": 1,
   "total_images": 3,
   "paused": false,
-  "mode": "individual",
   "started_at": "2026-02-15T14:30:00Z",
   "next_change_at": "2026-02-15T14:35:00Z",
-  "monitors": ["DP-1"]
+  "monitors": ["DP-1", "DP-2"],
+  "applied_to": ["DP-1"],
+  "extend": false
 }
 ```
 
+`monitors` is the set the user declared and is never narrowed by a disconnect;
+`applied_to` is the connected subset the wallpaper was applied to.
 `previous_image_id`, `next_image_id`, and `next_change_at` may be `null`.
 
 ### ActivePlaylistResponse
@@ -1241,10 +1251,11 @@ Alias of [`ActivePlaylistInstance`](#activeplaylistinstance), used for historica
   "next_image_id": 1,
   "total_images": 3,
   "paused": false,
-  "mode": "clone",
   "started_at": "2026-02-15T14:30:00Z",
   "next_change_at": "2026-02-15T14:35:00Z",
-  "monitors": ["DP-1", "HDMI-A-1"]
+  "monitors": ["DP-1", "HDMI-A-1"],
+  "applied_to": ["DP-1", "HDMI-A-1"],
+  "extend": false
 }
 ```
 

--- a/daemon/cmd/daemon/cli_playlists.go
+++ b/daemon/cmd/daemon/cli_playlists.go
@@ -219,8 +219,8 @@ func buildPlaylistDeleteCmd() *cobra.Command {
 }
 
 func buildPlaylistStartCmd() *cobra.Command {
-	var monitorID string
-	var mode string
+	var monitors string
+	var extend bool
 
 	cmd := &cobra.Command{
 		Use:   "start [id]",
@@ -232,18 +232,16 @@ func buildPlaylistStartCmd() *cobra.Command {
 				return err
 			}
 			body := map[string]any{
-				"monitor": map[string]any{
-					"id":   monitorID,
-					"mode": mode,
-				},
+				"monitors": parseStringList(monitors),
+				"extend":   extend,
 			}
 			return doJSONRequest("POST", "/playlists/"+id+"/start", body)
 		},
 	}
 
 	addPlaylistNameFlag(cmd)
-	cmd.Flags().StringVarP(&monitorID, "monitor", "m", "*", "target monitor ID (* for all)")
-	cmd.Flags().StringVar(&mode, "mode", "individual", "monitor mode (individual, clone, extend)")
+	cmd.Flags().StringVarP(&monitors, "monitors", "m", "", "comma-separated monitor names (default: all connected)")
+	cmd.Flags().BoolVar(&extend, "extend", false, "span one image across the monitors instead of cloning it")
 
 	return cmd
 }
@@ -393,6 +391,18 @@ func buildPlaylistPrevAllCmd() *cobra.Command {
 			return doSimpleRequest("POST", "/playlists/active/previous")
 		},
 	}
+}
+
+func parseStringList(s string) []string {
+	result := []string{}
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		result = append(result, part)
+	}
+	return result
 }
 
 func parseIntList(s string) []int {

--- a/daemon/internal/daemon/daemon.go
+++ b/daemon/internal/daemon/daemon.go
@@ -213,7 +213,7 @@ func (d *Daemon) Start(ctx context.Context) error {
 			opts.DB.ImageStore(), opts.DB.MonitorStateStore(), opts.DB.HistoryStore(), opts.DB.PlaylistStore(),
 			processor, bus, opts.Registry,
 		),
-		Playlists: playlistshandler.NewPlaylistHandler(opts.DB.PlaylistStore(), opts.DB.StateStore(), playlistMgr, bus),
+		Playlists: playlistshandler.NewPlaylistHandler(opts.DB.PlaylistStore(), opts.DB.StateStore(), playlistMgr, bus, monManager),
 		Monitors:  monitorshandler.NewMonitorHandler(monManager),
 		Config:    confighandler.NewConfigHandler(ctrl),
 		Backends:  backendshandler.NewBackendHandler(opts.Registry, ctrl),

--- a/daemon/internal/handler/playlistshandler/playlists.go
+++ b/daemon/internal/handler/playlistshandler/playlists.go
@@ -3,8 +3,10 @@ package playlistshandler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"slices"
 
 	"github.com/go-chi/chi/v5"
 
@@ -17,10 +19,11 @@ import (
 
 // PlaylistHandler handles all /playlists endpoints.
 type PlaylistHandler struct {
-	store      store.PlaylistStore
-	stateStore store.StateStore
-	manager    *playlist.Manager
-	bus        events.Bus
+	store          store.PlaylistStore
+	stateStore     store.StateStore
+	manager        *playlist.Manager
+	bus            events.Bus
+	monitorManager monitor.MonitorManager
 }
 
 // NewPlaylistHandler creates a PlaylistHandler.
@@ -29,12 +32,14 @@ func NewPlaylistHandler(
 	stateStore store.StateStore,
 	manager *playlist.Manager,
 	bus events.Bus,
+	monitorManager monitor.MonitorManager,
 ) *PlaylistHandler {
 	return &PlaylistHandler{
-		store:      store,
-		stateStore: stateStore,
-		manager:    manager,
-		bus:        bus,
+		store:          store,
+		stateStore:     stateStore,
+		manager:        manager,
+		bus:            bus,
+		monitorManager: monitorManager,
 	}
 }
 
@@ -155,13 +160,27 @@ func (h *PlaylistHandler) Delete(w http.ResponseWriter, r *http.Request) {
 
 // --- Playlist lifecycle actions ---
 
-// startRequest is the JSON body for POST /playlists/{id}/start.
-// Spec shape: { "monitor": { "id": "...", "mode": "..." } }
-type startRequest struct {
-	Monitor struct {
-		ID   string              `json:"id"`
-		Mode monitor.MonitorMode `json:"mode"`
-	} `json:"monitor"`
+func resolveDeclaredMonitors(ctx context.Context, mm monitor.MonitorManager, declared []string) ([]string, error) {
+	connected, err := mm.GetMonitors(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(declared) == 0 {
+		names := make([]string, 0, len(connected))
+		for _, mon := range connected {
+			names = append(names, mon.Name)
+		}
+		if len(names) == 0 {
+			return nil, errors.New("no monitors connected")
+		}
+		return names, nil
+	}
+	for _, mon := range connected {
+		if slices.Contains(declared, mon.Name) {
+			return declared, nil
+		}
+	}
+	return nil, fmt.Errorf("none of the monitors %v is connected", declared)
 }
 
 // Start handles POST /playlists/{id}/start.
@@ -172,22 +191,16 @@ func (h *PlaylistHandler) Start(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var req startRequest
-	if err := httpjson.ParseBody(r, &req); err != nil {
+	var target monitor.Target
+	if err := httpjson.ParseBody(r, &target); err != nil {
 		httpjson.WriteError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
-	if req.Monitor.ID == "" {
-		req.Monitor.ID = "*"
-	}
-	if req.Monitor.Mode == "" {
-		req.Monitor.Mode = monitor.ModeIndividual
-	}
-
-	target := monitor.MonitorTarget{
-		ID:   req.Monitor.ID,
-		Mode: req.Monitor.Mode,
+	target.Monitors, err = resolveDeclaredMonitors(r.Context(), h.monitorManager, target.Monitors)
+	if err != nil {
+		httpjson.WriteError(w, http.StatusBadRequest, err.Error())
+		return
 	}
 
 	if err := h.manager.Start(r.Context(), id, target); err != nil {

--- a/daemon/internal/handler/playlistshandler/playlists_test.go
+++ b/daemon/internal/handler/playlistshandler/playlists_test.go
@@ -24,7 +24,7 @@ func TestPlaylistHandler_List(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewPlaylistHandler(ps, &testutil.MockStateStore{}, nil, &testutil.MockBus{})
+	h := NewPlaylistHandler(ps, &testutil.MockStateStore{}, nil, &testutil.MockBus{}, &testutil.MockMonitorManager{})
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/playlists", nil)
@@ -44,7 +44,7 @@ func TestPlaylistHandler_Get_Found(t *testing.T) {
 			return &pl, nil
 		},
 	}
-	h := NewPlaylistHandler(ps, &testutil.MockStateStore{}, nil, &testutil.MockBus{})
+	h := NewPlaylistHandler(ps, &testutil.MockStateStore{}, nil, &testutil.MockBus{}, &testutil.MockMonitorManager{})
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/playlists/1", nil)
@@ -65,7 +65,7 @@ func TestPlaylistHandler_Get_NotFound(t *testing.T) {
 			return nil, store.ErrNotFound
 		},
 	}
-	h := NewPlaylistHandler(ps, &testutil.MockStateStore{}, nil, &testutil.MockBus{})
+	h := NewPlaylistHandler(ps, &testutil.MockStateStore{}, nil, &testutil.MockBus{}, &testutil.MockMonitorManager{})
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/playlists/999", nil)
@@ -82,7 +82,7 @@ func TestPlaylistHandler_Create(t *testing.T) {
 			return &created, nil
 		},
 	}
-	h := NewPlaylistHandler(ps, &testutil.MockStateStore{}, nil, &testutil.MockBus{})
+	h := NewPlaylistHandler(ps, &testutil.MockStateStore{}, nil, &testutil.MockBus{}, &testutil.MockMonitorManager{})
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/playlists",
@@ -104,7 +104,7 @@ func TestPlaylistHandler_Update(t *testing.T) {
 			return &pl, nil
 		},
 	}
-	h := NewPlaylistHandler(ps, &testutil.MockStateStore{}, nil, &testutil.MockBus{})
+	h := NewPlaylistHandler(ps, &testutil.MockStateStore{}, nil, &testutil.MockBus{}, &testutil.MockMonitorManager{})
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPatch, "/playlists/5",
@@ -125,7 +125,7 @@ func TestPlaylistHandler_Delete(t *testing.T) {
 			return nil
 		},
 	}
-	h := NewPlaylistHandler(ps, &testutil.MockStateStore{}, nil, &testutil.MockBus{})
+	h := NewPlaylistHandler(ps, &testutil.MockStateStore{}, nil, &testutil.MockBus{}, &testutil.MockMonitorManager{})
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodDelete, "/playlists/3", nil)
@@ -142,7 +142,7 @@ func TestPlaylistHandler_Delete_NotFound(t *testing.T) {
 			return errors.New("playlist not found")
 		},
 	}
-	h := NewPlaylistHandler(ps, &testutil.MockStateStore{}, nil, &testutil.MockBus{})
+	h := NewPlaylistHandler(ps, &testutil.MockStateStore{}, nil, &testutil.MockBus{}, &testutil.MockMonitorManager{})
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodDelete, "/playlists/999", nil)
@@ -161,13 +161,13 @@ func TestPlaylistHandler_ListActive(t *testing.T) {
 						PlaylistID:   1,
 						PlaylistName: "Morning",
 					},
-					Mode:     "individual",
-					Monitors: []string{"HDMI-A-1"},
+					Monitors:  []string{"HDMI-A-1"},
+					AppliedTo: []string{"HDMI-A-1"},
 				},
 			}
 		},
 	}
-	h := NewPlaylistHandler(&testutil.MockPlaylistStore{}, ss, nil, &testutil.MockBus{})
+	h := NewPlaylistHandler(&testutil.MockPlaylistStore{}, ss, nil, &testutil.MockBus{}, &testutil.MockMonitorManager{})
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/playlists/active", nil)
@@ -223,7 +223,7 @@ func TestPreviousAllResponse_WireFormat(t *testing.T) {
 }
 
 func TestPlaylistHandler_Get_BadID(t *testing.T) {
-	h := NewPlaylistHandler(&testutil.MockPlaylistStore{}, &testutil.MockStateStore{}, nil, &testutil.MockBus{})
+	h := NewPlaylistHandler(&testutil.MockPlaylistStore{}, &testutil.MockStateStore{}, nil, &testutil.MockBus{}, &testutil.MockMonitorManager{})
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/playlists/abc", nil)

--- a/daemon/internal/handler/playlistshandler/start_test.go
+++ b/daemon/internal/handler/playlistshandler/start_test.go
@@ -1,0 +1,62 @@
+package playlistshandler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"waypaper-engine/daemon/internal/monitor"
+	"waypaper-engine/daemon/internal/testutil"
+)
+
+func connectedMonitors(names ...string) *testutil.MockMonitorManager {
+	return &testutil.MockMonitorManager{
+		GetMonitorsFn: func(_ context.Context) ([]monitor.Monitor, error) {
+			mons := make([]monitor.Monitor, 0, len(names))
+			for _, n := range names {
+				mons = append(mons, monitor.Monitor{Name: n})
+			}
+			return mons, nil
+		},
+	}
+}
+
+func TestResolveDeclaredMonitors_explicitNamesPassThrough(t *testing.T) {
+	got, err := resolveDeclaredMonitors(context.Background(), connectedMonitors("DP-1"), []string{"DP-1", "DP-2"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"DP-1", "DP-2"}, got)
+}
+
+func TestResolveDeclaredMonitors_emptyExpandsToConnected(t *testing.T) {
+	mm := connectedMonitors("DP-1", "DP-2")
+
+	got, err := resolveDeclaredMonitors(context.Background(), mm, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"DP-1", "DP-2"}, got)
+
+	got, err = resolveDeclaredMonitors(context.Background(), mm, []string{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"DP-1", "DP-2"}, got)
+}
+
+func TestResolveDeclaredMonitors_noneConnectedIsError(t *testing.T) {
+	_, err := resolveDeclaredMonitors(context.Background(), connectedMonitors("DP-1"), []string{"DP-9"})
+	assert.Error(t, err)
+}
+
+func TestPlaylistHandler_Start_noneConnectedIsBadRequest(t *testing.T) {
+	h := NewPlaylistHandler(&testutil.MockPlaylistStore{}, &testutil.MockStateStore{}, nil, &testutil.MockBus{},
+		connectedMonitors("DP-1"))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/playlists/1/start",
+		testutil.JSONBody(t, map[string]any{"monitors": []string{"DP-9"}}))
+	r = testutil.WithChiURLParams(r, map[string]string{"id": "1"})
+	h.Start(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/daemon/internal/monitor/types.go
+++ b/daemon/internal/monitor/types.go
@@ -29,6 +29,13 @@ const (
 	ModeExtend MonitorMode = "extend"
 )
 
+func NormalizeMode(mode MonitorMode, monitors int) MonitorMode {
+	if monitors <= 1 {
+		return ModeIndividual
+	}
+	return mode
+}
+
 // Monitor represents a single physical display with its geometry and metadata.
 //
 // Fields beyond name/width/height/x/y/scale/refresh_rate/transform are sourced
@@ -109,11 +116,7 @@ func parseTransform(s string) int {
 	}
 }
 
-// MonitorTarget is used in API request bodies to specify which monitor(s) an action targets.
-type MonitorTarget struct {
-	// ID is the monitor name (e.g. "HDMI-A-1") or "*" for all monitors.
-	ID string `json:"id"`
-
-	// Mode is how the wallpaper should be applied.
-	Mode MonitorMode `json:"mode"`
+type Target struct {
+	Monitors []string `json:"monitors"`
+	Extend   bool     `json:"extend"`
 }

--- a/daemon/internal/playlist/manager.go
+++ b/daemon/internal/playlist/manager.go
@@ -31,7 +31,7 @@ type playlistRun struct {
 	playCtx    context.Context
 	playlistID int
 	monitors   []monitor.Monitor
-	target     monitor.MonitorTarget
+	target     monitor.Target
 }
 
 // Manager handles playlist lifecycle: start, stop, pause, resume, next, previous.
@@ -81,7 +81,7 @@ func NewManager(
 }
 
 // Start begins a playlist on the specified target monitor(s).
-func (m *Manager) Start(ctx context.Context, playlistID int, target monitor.MonitorTarget) error {
+func (m *Manager) Start(ctx context.Context, playlistID int, target monitor.Target) error {
 	return m.startPlaylist(ctx, playlistID, target, startOpts{})
 }
 
@@ -98,7 +98,7 @@ func setSlotDeadline(inst *store.ActivePlaylistInstance, next *time.Time) {
 	inst.SlotStartedAt = &now
 }
 
-func (m *Manager) startPlaylist(ctx context.Context, playlistID int, target monitor.MonitorTarget, opts startOpts) error {
+func (m *Manager) startPlaylist(ctx context.Context, playlistID int, target monitor.Target, opts startOpts) error {
 	pl, err := m.playlistStore.GetByID(ctx, playlistID)
 	if err != nil {
 		return fmt.Errorf("playlist manager: load playlist: %w", err)
@@ -108,20 +108,12 @@ func (m *Manager) startPlaylist(ctx context.Context, playlistID int, target moni
 		return fmt.Errorf("playlist manager: playlist %d has no images", playlistID)
 	}
 
-	targetEff := target
-	if opts.fromPersisted && pl.Playback != nil {
-		targetEff = playbackToTarget(pl.Playback)
-	}
-
-	monitors, err := m.resolveMonitors(ctx, targetEff)
+	monitors, err := m.connectedDeclaredMonitors(ctx, target.Monitors)
 	if err != nil {
 		return err
 	}
-	if len(monitors) == 0 {
-		return fmt.Errorf("playlist manager: no monitors resolved for target %q", targetEff.ID)
-	}
 
-	targetNames := monitorNameSet(monitors)
+	targetNames := monitorNameSet2(target.Monitors)
 	for _, inst := range m.stateStore.GetActivePlaylists() {
 		if monitorsOverlap(inst.Monitors, targetNames) {
 			id := inst.PlaylistID
@@ -159,7 +151,7 @@ func (m *Manager) startPlaylist(ctx context.Context, playlistID int, target moni
 		playCtx:    playCtx,
 		playlistID: pl.ID,
 		monitors:   monitors,
-		target:     targetEff,
+		target:     target,
 	}
 
 	m.mu.Lock()
@@ -167,12 +159,12 @@ func (m *Manager) startPlaylist(ctx context.Context, playlistID int, target moni
 	m.mu.Unlock()
 
 	if playlistTypeNeedsMissedEventChecker(pl.Configuration.Type) {
-		go m.missedEventChecker(playCtx, pl.ID, monitors, targetEff)
+		go m.missedEventChecker(playCtx, pl.ID, monitors, target)
 	}
 
 	effectiveIdx := applyRow
 	if !opts.fromPersisted {
-		result, err := m.applyImage(ctx, pl, applyRow, monitors, targetEff.Mode, compatForward)
+		result, err := m.applyImage(ctx, pl, applyRow, monitors, applyModeFor(target.Extend), compatForward)
 		if err != nil {
 			slog.Warn("playlist: failed to apply first image", "error", err)
 		}
@@ -186,10 +178,10 @@ func (m *Manager) startPlaylist(ctx context.Context, playlistID int, target moni
 	// the retry-loop collision.
 
 	sched.Start(func(index int) bool {
-		return m.onTick(playCtx, pl.ID, index, monitors, targetEff)
+		return m.onTick(playCtx, pl.ID, index, monitors, target)
 	})
 
-	monNames := monitorNames(monitors)
+	appliedNames := monitorNames(monitors)
 	nextAt := sched.NextChangeAt()
 	if resumePaused {
 		nextAt = nil
@@ -203,8 +195,9 @@ func (m *Manager) startPlaylist(ctx context.Context, playlistID int, target moni
 			Paused:       resumePaused,
 			StartedAt:    time.Now(),
 		},
-		Mode:     string(targetEff.Mode),
-		Monitors: monNames,
+		Monitors:  append([]string(nil), target.Monitors...),
+		AppliedTo: appliedNames,
+		Extend:    target.Extend,
 	}
 	setSlotDeadline(&instance, nextAt)
 	updateInstanceIndex(&instance, pl, effectiveIdx)
@@ -219,12 +212,13 @@ func (m *Manager) startPlaylist(ctx context.Context, playlistID int, target moni
 		Data: map[string]any{
 			"playlist_id":   pl.ID,
 			"playlist_name": pl.Name,
-			"monitors":      monNames,
-			"mode":          targetEff.Mode,
+			"monitors":      target.Monitors,
+			"applied_to":    appliedNames,
+			"extend":        target.Extend,
 		},
 	})
 
-	slog.Info("playlist started", "id", pl.ID, "name", pl.Name, "monitors", monNames)
+	slog.Info("playlist started", "id", pl.ID, "name", pl.Name, "monitors", target.Monitors, "applied_to", appliedNames)
 	return nil
 }
 
@@ -474,8 +468,6 @@ func (m *Manager) advancePlaylist(ctx context.Context, playlistID int, delta int
 		return fmt.Errorf("playlist manager: playlist %d is not running", playlistID)
 	}
 
-	mode := monitor.MonitorMode(inst.Mode)
-
 	pl, err := m.playlistStore.GetByID(ctx, playlistID)
 	if err != nil {
 		return err
@@ -516,7 +508,7 @@ func (m *Manager) advancePlaylist(ctx context.Context, playlistID int, delta int
 	if delta < 0 {
 		walk = compatBackward
 	}
-	result, applyErr := m.applyImage(ctx, pl, newIdx, targetMonitors, mode, walk)
+	result, applyErr := m.applyImage(ctx, pl, newIdx, targetMonitors, applyModeFor(inst.Extend), walk)
 	if applyErr != nil {
 		return applyErr
 	}
@@ -636,7 +628,7 @@ func (m *Manager) ReconcileAfterPlaylistUpdate(ctx context.Context, playlistID i
 
 // onTick is called by the scheduler when it's time to change the wallpaper.
 // Returns whether the slide was applied; the timer scheduler only advances traversal when true.
-func (m *Manager) onTick(ctx context.Context, playlistID int, index int, monitors []monitor.Monitor, target monitor.MonitorTarget) bool {
+func (m *Manager) onTick(ctx context.Context, playlistID int, index int, monitors []monitor.Monitor, target monitor.Target) bool {
 	pl, err := m.playlistStore.GetByID(ctx, playlistID)
 	if err != nil {
 		slog.Warn("playlist tick: load playlist", "playlist_id", playlistID, "error", err)
@@ -646,7 +638,7 @@ func (m *Manager) onTick(ctx context.Context, playlistID int, index int, monitor
 		return false
 	}
 
-	result, err := m.applyImage(ctx, pl, index, monitors, target.Mode, compatForward)
+	result, err := m.applyImage(ctx, pl, index, monitors, applyModeFor(target.Extend), compatForward)
 	if err != nil {
 		slog.Warn("playlist tick: failed to apply image", "playlist_id", playlistID, "index", index, "error", err)
 		return false
@@ -920,28 +912,36 @@ func findCompatibleIndexWithWalk(ctx context.Context, pl *store.Playlist, start 
 	return -1, n, skippedItems
 }
 
-// resolveMonitors resolves the target specification to concrete monitors.
-func (m *Manager) resolveMonitors(ctx context.Context, target monitor.MonitorTarget) ([]monitor.Monitor, error) {
-	if target.ID == "*" {
-		monitors, err := m.monitorManager.GetMonitors(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("playlist manager: get monitors: %w", err)
-		}
-		return monitors, nil
-	}
-
-	mon, err := m.monitorManager.GetMonitorByName(ctx, target.ID)
+func (m *Manager) connectedDeclaredMonitors(ctx context.Context, declared []string) ([]monitor.Monitor, error) {
+	connected, err := m.monitorManager.GetMonitors(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("playlist manager: get monitor %s: %w", target.ID, err)
+		return nil, fmt.Errorf("playlist manager: get monitors: %w", err)
 	}
-	return []monitor.Monitor{mon}, nil
+	declaredSet := monitorNameSet2(declared)
+	var out []monitor.Monitor
+	for _, mon := range connected {
+		if _, ok := declaredSet[mon.Name]; ok {
+			out = append(out, mon)
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("playlist manager: none of the declared monitors %v is connected", declared)
+	}
+	return out, nil
+}
+
+func applyModeFor(extend bool) monitor.MonitorMode {
+	if extend {
+		return monitor.ModeExtend
+	}
+	return monitor.ModeClone
 }
 
 // missedEventChecker polls every 10 seconds to detect missed scheduler events
 // (e.g. after system sleep/wake). If the expected next change time has passed
 // by more than 30 seconds, it re-triggers the scheduler by computing the
 // correct current image and applying it.
-func (m *Manager) missedEventChecker(ctx context.Context, playlistID int, monitors []monitor.Monitor, target monitor.MonitorTarget) {
+func (m *Manager) missedEventChecker(ctx context.Context, playlistID int, monitors []monitor.Monitor, target monitor.Target) {
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
 
@@ -985,7 +985,7 @@ func (m *Manager) missedEventChecker(ctx context.Context, playlistID int, monito
 					continue
 				}
 
-				result, applyErr := m.applyImage(ctx, pl, newIdx, monitors, target.Mode, compatForward)
+				result, applyErr := m.applyImage(ctx, pl, newIdx, monitors, applyModeFor(target.Extend), compatForward)
 				if applyErr != nil {
 					slog.Warn("missed event: failed to apply image", "error", applyErr)
 					continue
@@ -1148,15 +1148,6 @@ func monitorNames(monitors []monitor.Monitor) []string {
 		names[i] = mon.Name
 	}
 	return names
-}
-
-// monitorNameSet builds a set from monitor objects for O(1) membership checks.
-func monitorNameSet(monitors []monitor.Monitor) map[string]struct{} {
-	s := make(map[string]struct{}, len(monitors))
-	for _, mon := range monitors {
-		s[mon.Name] = struct{}{}
-	}
-	return s
 }
 
 // monitorNameSet2 builds a set from a string slice.

--- a/daemon/internal/playlist/manual_advance_test.go
+++ b/daemon/internal/playlist/manual_advance_test.go
@@ -61,7 +61,7 @@ func TestNext_RejectsTimeOfDayAndDayOfWeek(t *testing.T) {
 				&simpleRegistry{active: &recordingBackend{}}, monMgr, &noopBus{}, nil, &noopConfig{},
 			)
 
-			require.NoError(t, mgr.Start(ctx, tc.pl.ID, monitor.MonitorTarget{ID: "DP-1", Mode: monitor.ModeIndividual}))
+			require.NoError(t, mgr.Start(ctx, tc.pl.ID, monitor.Target{Monitors: []string{"DP-1"}}))
 
 			err := mgr.Next(ctx, tc.pl.ID)
 			require.Error(t, err)
@@ -115,8 +115,8 @@ func TestNextAll_MixedSkipsScheduleOnly(t *testing.T) {
 		&simpleRegistry{active: &recordingBackend{}}, monMgr, &noopBus{}, nil, &noopConfig{},
 	)
 
-	require.NoError(t, mgr.Start(ctx, 1, monitor.MonitorTarget{ID: "DP-1", Mode: monitor.ModeIndividual}))
-	require.NoError(t, mgr.Start(ctx, 2, monitor.MonitorTarget{ID: "HDMI-A-1", Mode: monitor.ModeIndividual}))
+	require.NoError(t, mgr.Start(ctx, 1, monitor.Target{Monitors: []string{"DP-1"}}))
+	require.NoError(t, mgr.Start(ctx, 2, monitor.Target{Monitors: []string{"HDMI-A-1"}}))
 
 	n, err := mgr.NextAll(ctx)
 	require.NoError(t, err)
@@ -164,8 +164,8 @@ func TestNextAll_AllSchedulePlaylistsReturnsErr(t *testing.T) {
 		&simpleRegistry{active: &recordingBackend{}}, monMgr, &noopBus{}, nil, &noopConfig{},
 	)
 
-	require.NoError(t, mgr.Start(ctx, 1, monitor.MonitorTarget{ID: "DP-1", Mode: monitor.ModeIndividual}))
-	require.NoError(t, mgr.Start(ctx, 2, monitor.MonitorTarget{ID: "HDMI-A-1", Mode: monitor.ModeIndividual}))
+	require.NoError(t, mgr.Start(ctx, 1, monitor.Target{Monitors: []string{"DP-1"}}))
+	require.NoError(t, mgr.Start(ctx, 2, monitor.Target{Monitors: []string{"HDMI-A-1"}}))
 
 	_, err := mgr.NextAll(ctx)
 	require.Error(t, err)

--- a/daemon/internal/playlist/playback_persist.go
+++ b/daemon/internal/playlist/playback_persist.go
@@ -53,17 +53,6 @@ func advancePlaylistRow(inst *store.ActivePlaylistInstance, pl *store.Playlist, 
 	return (cur + delta + n) % n
 }
 
-func playbackToTarget(pb *store.PlaylistPlayback) monitor.MonitorTarget {
-	mode := monitor.MonitorMode(pb.Mode)
-	if mode == "" {
-		mode = monitor.ModeIndividual
-	}
-	if len(pb.Monitors) == 1 {
-		return monitor.MonitorTarget{ID: pb.Monitors[0], Mode: mode}
-	}
-	return monitor.MonitorTarget{ID: "*", Mode: mode}
-}
-
 func (m *Manager) playlistStartIndices(pl *store.Playlist, opts startOpts) (timeSlots []TimeSlot, startIdx int, timerIdx []int, timerCur int) {
 	pb := pl.Playback
 	n := len(pl.Images)
@@ -117,8 +106,8 @@ func (m *Manager) buildPlayback(inst *store.ActivePlaylistInstance, pl *store.Pl
 		WasRunning:   wasRunning,
 		CurrentIndex: resolvePlaylistRowForPlayback(inst, pl),
 		Paused:       inst.Paused,
-		Mode:         inst.Mode,
 		Monitors:     append([]string(nil), inst.Monitors...),
+		Extend:       inst.Extend,
 	}
 	if pl.Configuration.Type == "timer" && pl.Configuration.Order == "random" && run != nil {
 		idx, cur, ok := TimerTraversalSnapshot(run.sched)
@@ -166,7 +155,7 @@ func (m *Manager) RestorePersistedRuns(ctx context.Context) error {
 		if pl.Playback == nil || !pl.Playback.WasRunning || len(pl.Images) == 0 {
 			continue
 		}
-		target := playbackToTarget(pl.Playback)
+		target := monitor.Target{Monitors: pl.Playback.Monitors, Extend: pl.Playback.Extend}
 		if err := m.startPlaylist(ctx, pl.ID, target, startOpts{fromPersisted: true}); err != nil {
 			slog.Warn("playlist restore failed", "playlist_id", pl.ID, "error", err)
 		}

--- a/daemon/internal/playlist/playback_resolve_test.go
+++ b/daemon/internal/playlist/playback_resolve_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"waypaper-engine/daemon/internal/monitor"
 	"waypaper-engine/daemon/internal/store"
 )
 
@@ -65,4 +66,10 @@ func TestAdvancePlaylistRow_wrapAtEnds(t *testing.T) {
 	}}
 	assert.Equal(t, 0, advancePlaylistRow(inst, pl, 1))
 	assert.Equal(t, 1, advancePlaylistRow(inst, pl, -1))
+}
+
+func TestNormalizeMode(t *testing.T) {
+	assert.Equal(t, monitor.ModeIndividual, monitor.NormalizeMode(monitor.ModeClone, 1))
+	assert.Equal(t, monitor.ModeIndividual, monitor.NormalizeMode(monitor.ModeExtend, 0))
+	assert.Equal(t, monitor.ModeClone, monitor.NormalizeMode(monitor.ModeClone, 2))
 }

--- a/daemon/internal/playlist/reconcile_test.go
+++ b/daemon/internal/playlist/reconcile_test.go
@@ -67,7 +67,7 @@ func TestReconcileAfterPlaylistUpdate_InsertAndReorder(t *testing.T) {
 	)
 
 	// Start: applies img1 (index 0).
-	target := monitor.MonitorTarget{ID: "DP-1", Mode: monitor.ModeIndividual}
+	target := monitor.Target{Monitors: []string{"DP-1"}}
 	require.NoError(t, mgr.Start(ctx, 1, target))
 
 	rec.mu.Lock()
@@ -173,7 +173,7 @@ func TestReconcileAfterPlaylistUpdate_CurrentImageMovedSlot(t *testing.T) {
 		&simpleRegistry{active: rec}, monMgr, &noopBus{}, nil, &noopConfig{},
 	)
 
-	require.NoError(t, mgr.Start(ctx, 2, monitor.MonitorTarget{ID: "DP-1", Mode: monitor.ModeIndividual}))
+	require.NoError(t, mgr.Start(ctx, 2, monitor.Target{Monitors: []string{"DP-1"}}))
 
 	// Simulate: currently at img3 (index 2 in old list).
 	stateStore.UpdateActivePlaylist(2, func(inst *store.ActivePlaylistInstance) {
@@ -261,7 +261,7 @@ func TestReconcileAfterPlaylistUpdate_ShortInterval_TickShowsNextImage(t *testin
 		&simpleRegistry{active: rec}, monMgr, &noopBus{}, nil, &noopConfig{},
 	)
 
-	require.NoError(t, mgr.Start(ctx, 3, monitor.MonitorTarget{ID: "DP-1", Mode: monitor.ModeIndividual}))
+	require.NoError(t, mgr.Start(ctx, 3, monitor.Target{Monitors: []string{"DP-1"}}))
 
 	// Simulate currently at img2 (index 1).
 	stateStore.UpdateActivePlaylist(3, func(inst *store.ActivePlaylistInstance) {

--- a/daemon/internal/playlist/restore_test.go
+++ b/daemon/internal/playlist/restore_test.go
@@ -324,7 +324,6 @@ func TestRestorePersistedRuns_DoesNotReapplyWallpaper(t *testing.T) {
 		Playback: &store.PlaylistPlayback{
 			WasRunning:   true,
 			CurrentIndex: 0,
-			Mode:         string(monitor.ModeIndividual),
 			Monitors:     []string{"DP-1"},
 		},
 	}
@@ -342,7 +341,6 @@ func TestRestorePersistedRuns_DoesNotReapplyWallpaper(t *testing.T) {
 		Playback: &store.PlaylistPlayback{
 			WasRunning:   true,
 			CurrentIndex: 0,
-			Mode:         string(monitor.ModeIndividual),
 			Monitors:     []string{"DP-2"},
 		},
 	}

--- a/daemon/internal/playlist/slot_started_at_test.go
+++ b/daemon/internal/playlist/slot_started_at_test.go
@@ -49,7 +49,7 @@ func TestStartPlaylist_SetsSlotStartedAt(t *testing.T) {
 	)
 
 	before := time.Now()
-	require.NoError(t, mgr.Start(ctx, 1, monitor.MonitorTarget{ID: "DP-1", Mode: monitor.ModeIndividual}))
+	require.NoError(t, mgr.Start(ctx, 1, monitor.Target{Monitors: []string{"DP-1"}}))
 	after := time.Now()
 
 	inst := stateStore.GetActivePlaylistByID(1)
@@ -104,7 +104,7 @@ func TestOnTick_UpdatesSlotStartedAt(t *testing.T) {
 		&simpleRegistry{active: rec}, monMgr, &noopBus{}, nil, &noopConfig{},
 	)
 
-	require.NoError(t, mgr.Start(ctx, 2, monitor.MonitorTarget{ID: "DP-1", Mode: monitor.ModeIndividual}))
+	require.NoError(t, mgr.Start(ctx, 2, monitor.Target{Monitors: []string{"DP-1"}}))
 
 	instAfterStart := stateStore.GetActivePlaylistByID(2)
 	require.NotNil(t, instAfterStart)
@@ -117,7 +117,7 @@ func TestOnTick_UpdatesSlotStartedAt(t *testing.T) {
 	// direct way to exercise that path.
 	monitors, err := monMgr.GetMonitors(ctx)
 	require.NoError(t, err)
-	applied := mgr.onTick(ctx, 2, 1, monitors, monitor.MonitorTarget{ID: "DP-1", Mode: monitor.ModeIndividual})
+	applied := mgr.onTick(ctx, 2, 1, monitors, monitor.Target{Monitors: []string{"DP-1"}})
 	require.True(t, applied, "onTick should have applied the next image")
 
 	instAfterTick := stateStore.GetActivePlaylistByID(2)
@@ -161,7 +161,7 @@ func TestPauseResume_SlotStartedAtTracksNextChangeAt(t *testing.T) {
 		&simpleRegistry{active: &recordingBackend{}}, monMgr, &noopBus{}, nil, &noopConfig{},
 	)
 
-	require.NoError(t, mgr.Start(ctx, 4, monitor.MonitorTarget{ID: "DP-1", Mode: monitor.ModeIndividual}))
+	require.NoError(t, mgr.Start(ctx, 4, monitor.Target{Monitors: []string{"DP-1"}}))
 	require.NoError(t, mgr.Pause(ctx, 4))
 
 	pausedInst := stateStore.GetActivePlaylistByID(4)

--- a/daemon/internal/playlist/target_test.go
+++ b/daemon/internal/playlist/target_test.go
@@ -1,0 +1,113 @@
+package playlist
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"waypaper-engine/daemon/internal/monitor"
+	"waypaper-engine/daemon/internal/store"
+)
+
+func newTargetTestManager(t *testing.T, connected ...string) (*Manager, *inMemPlaylistStore, *inMemStateStore) {
+	t.Helper()
+
+	pl := &store.Playlist{
+		ID:   1,
+		Name: "declared",
+		Images: []store.PlaylistImage{
+			{ImageID: 10, MediaType: "image"},
+		},
+		Configuration: store.PlaylistConfiguration{
+			Type:     "timer",
+			Interval: 3600,
+			Order:    "ordered",
+		},
+	}
+
+	monitors := make([]monitor.Monitor, 0, len(connected))
+	for _, name := range connected {
+		monitors = append(monitors, monitor.Monitor{Name: name})
+	}
+
+	playlistStore := newInMemPlaylistStore(pl)
+	stateStore := newInMemStateStore()
+
+	mgr := NewManager(
+		playlistStore,
+		stateStore,
+		&noopHistoryStore{},
+		&stubImageStore{images: map[int]*store.Image{
+			10: {ID: 10, Path: "/a.jpg", MediaType: "image"},
+		}},
+		&noopMonitorStateStore{},
+		&simpleRegistry{active: &recordingBackend{}},
+		&staticMonitorManager{monitors: monitors},
+		&noopBus{},
+		nil,
+		&noopConfig{},
+	)
+	return mgr, playlistStore, stateStore
+}
+
+func TestStart_keepsDeclaredMonitorsAndRecordsAppliedSubset(t *testing.T) {
+	ctx := context.Background()
+	mgr, _, stateStore := newTargetTestManager(t, "DP-1")
+
+	require.NoError(t, mgr.Start(ctx, 1, monitor.Target{Monitors: []string{"DP-1", "DP-2"}}))
+
+	inst := stateStore.GetActivePlaylistByID(1)
+	require.NotNil(t, inst)
+	assert.Equal(t, []string{"DP-1", "DP-2"}, inst.Monitors)
+	assert.Equal(t, []string{"DP-1"}, inst.AppliedTo)
+}
+
+func TestStart_noDeclaredMonitorConnectedFails(t *testing.T) {
+	ctx := context.Background()
+	mgr, _, _ := newTargetTestManager(t, "DP-1")
+
+	require.Error(t, mgr.Start(ctx, 1, monitor.Target{Monitors: []string{"DP-9"}}))
+}
+
+func TestStartStopStart_declaredSetIsIdenticalEveryTime(t *testing.T) {
+	ctx := context.Background()
+	mgr, _, stateStore := newTargetTestManager(t, "DP-1")
+
+	declared := []string{"DP-1", "DP-2"}
+
+	require.NoError(t, mgr.Start(ctx, 1, monitor.Target{Monitors: declared}))
+	first := stateStore.GetActivePlaylistByID(1).Monitors
+
+	require.NoError(t, mgr.Stop(ctx, 1))
+
+	require.NoError(t, mgr.Start(ctx, 1, monitor.Target{Monitors: declared}))
+	second := stateStore.GetActivePlaylistByID(1).Monitors
+
+	assert.Equal(t, declared, first)
+	assert.Equal(t, declared, second)
+}
+
+func TestPlaybackRoundTrip_restoresFullDeclaredSet(t *testing.T) {
+	ctx := context.Background()
+	mgr, playlistStore, stateStore := newTargetTestManager(t, "DP-1")
+
+	require.NoError(t, mgr.Start(ctx, 1, monitor.Target{Monitors: []string{"DP-1", "DP-2"}, Extend: true}))
+	mgr.Shutdown(ctx)
+
+	playlistStore.mu.RLock()
+	pb := playlistStore.playbacks[1]
+	playlistStore.mu.RUnlock()
+	require.NotNil(t, pb)
+	assert.Equal(t, []string{"DP-1", "DP-2"}, pb.Monitors)
+	assert.True(t, pb.Extend)
+
+	require.NoError(t, mgr.RestorePersistedRuns(ctx))
+
+	inst := stateStore.GetActivePlaylistByID(1)
+	require.NotNil(t, inst)
+	assert.Equal(t, []string{"DP-1", "DP-2"}, inst.Monitors)
+	assert.Equal(t, []string{"DP-1"}, inst.AppliedTo)
+	assert.True(t, inst.Extend)
+}

--- a/daemon/internal/playlist/timer_reload.go
+++ b/daemon/internal/playlist/timer_reload.go
@@ -50,7 +50,7 @@ func (m *Manager) timerReloadAfterPlaylistDocumentChange(
 
 	oldSched.Stop()
 
-	res, applyErr := m.applyImage(ctx, pl, anchorRow, monitors, target.Mode, compatForward)
+	res, applyErr := m.applyImage(ctx, pl, anchorRow, monitors, applyModeFor(target.Extend), compatForward)
 	row := anchorRow
 	if applyErr != nil {
 		slog.Warn("playlist reconcile: apply image", "playlist_id", playlistID, "error", applyErr)

--- a/daemon/internal/store/models.go
+++ b/daemon/internal/store/models.go
@@ -258,8 +258,8 @@ type PlaylistPlayback struct {
 	WasRunning   bool     `json:"was_running"`
 	CurrentIndex int      `json:"current_index"`
 	Paused       bool     `json:"paused"`
-	Mode         string   `json:"mode"`
 	Monitors     []string `json:"monitors"`
+	Extend       bool     `json:"extend"`
 	// TimerIndices is the shuffled row order for timer+random; length must match
 	// images when present.
 	TimerIndices []int `json:"timer_indices,omitempty"`
@@ -351,6 +351,7 @@ type ActivePlaylistState struct {
 // Keyed by playlist ID in the state store.
 type ActivePlaylistInstance struct {
 	ActivePlaylistState
-	Mode     string   `json:"mode"`
-	Monitors []string `json:"monitors"`
+	Monitors  []string `json:"monitors"`
+	AppliedTo []string `json:"applied_to"`
+	Extend    bool     `json:"extend"`
 }

--- a/daemon/internal/store/store_test.go
+++ b/daemon/internal/store/store_test.go
@@ -726,8 +726,8 @@ func TestPlaylistStore_SavePlaybackState(t *testing.T) {
 		WasRunning:   true,
 		CurrentIndex: 2,
 		Paused:       true,
-		Mode:         "individual",
 		Monitors:     []string{"DP-1"},
+		Extend:       true,
 		TimerIndices: []int{1, 0},
 		TimerCursor:  0,
 	}
@@ -741,6 +741,7 @@ func TestPlaylistStore_SavePlaybackState(t *testing.T) {
 	assert.Equal(t, 2, got.Playback.CurrentIndex)
 	assert.True(t, got.Playback.Paused)
 	assert.Equal(t, []string{"DP-1"}, got.Playback.Monitors)
+	assert.True(t, got.Playback.Extend)
 	assert.Equal(t, []int{1, 0}, got.Playback.TimerIndices)
 	assert.Equal(t, 0, got.Playback.TimerCursor)
 
@@ -1024,7 +1025,6 @@ func TestStateStore_ActivePlaylist(t *testing.T) {
 			TotalImages:  5,
 			StartedAt:    time.Now(),
 		},
-		Mode:     "individual",
 		Monitors: []string{"HDMI-A-1"},
 	}
 	ss.SetActivePlaylist(instance)
@@ -1052,7 +1052,6 @@ func TestStateStore_GetActivePlaylists(t *testing.T) {
 			PlaylistName: "Playlist HDMI",
 			StartedAt:    time.Now(),
 		},
-		Mode:     "individual",
 		Monitors: []string{"HDMI-A-1"},
 	})
 	ss.SetActivePlaylist(store.ActivePlaylistInstance{
@@ -1061,7 +1060,6 @@ func TestStateStore_GetActivePlaylists(t *testing.T) {
 			PlaylistName: "Playlist DP",
 			StartedAt:    time.Now(),
 		},
-		Mode:     "individual",
 		Monitors: []string{"DP-1"},
 	})
 
@@ -1080,7 +1078,6 @@ func TestStateStore_RemoveActivePlaylist(t *testing.T) {
 			PlaylistID: 1,
 			StartedAt:  time.Now(),
 		},
-		Mode:     "individual",
 		Monitors: []string{"HDMI-A-1"},
 	})
 
@@ -1100,7 +1097,6 @@ func TestStateStore_RemoveAllActivePlaylists(t *testing.T) {
 			PlaylistID: 1,
 			StartedAt:  time.Now(),
 		},
-		Mode:     "individual",
 		Monitors: []string{"HDMI-A-1", "DP-1", "DP-2"},
 	})
 
@@ -1120,7 +1116,6 @@ func TestStateStore_UpdateActivePlaylist(t *testing.T) {
 			PlaylistName: "Test",
 			StartedAt:    time.Now(),
 		},
-		Mode:     "individual",
 		Monitors: []string{"HDMI-A-1"},
 	})
 

--- a/daemon/internal/wallpaper/apply.go
+++ b/daemon/internal/wallpaper/apply.go
@@ -34,6 +34,8 @@ type ApplyOpts struct {
 // Flow: build prospective snapshot → backend.Apply → persist + history + SSE.
 // On error: DB unchanged, SSE wallpaper_apply_failed.
 func Apply(ctx context.Context, opts ApplyOpts) error {
+	opts.Mode = monitor.NormalizeMode(opts.Mode, len(opts.Monitors))
+
 	snap, err := buildApplySnapshot(ctx, opts)
 	if err != nil {
 		return err

--- a/electron/daemon-go-types.ts
+++ b/electron/daemon-go-types.ts
@@ -254,11 +254,12 @@ export interface ActivePlaylistInstance {
   next_image_id: number | null;
   total_images: number;
   paused: boolean;
-  mode: MonitorMode;
   started_at: string;
   next_change_at: string | null;
   slot_started_at: string | null;
   monitors: string[];
+  applied_to: string[];
+  extend: boolean;
 }
 
 // ============================================================================
@@ -603,10 +604,8 @@ export interface SetWallpaperResponse {
 }
 
 export interface StartPlaylistRequest {
-  monitor?: {
-    id?: string;
-    mode?: MonitorMode;
-  };
+  monitors?: string[];
+  extend?: boolean;
 }
 
 export interface CreatePlaylistRequest {

--- a/electron/daemonClient/playlistsClient.test.ts
+++ b/electron/daemonClient/playlistsClient.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { PlaylistsClient } from "./playlistsClient";
+import type { HttpTransport } from "./httpTransport";
+
+interface CapturedRequest {
+  method: string;
+  path: string;
+  body: unknown;
+}
+
+function clientCapturingRequests(requests: CapturedRequest[]): PlaylistsClient {
+  const transport = {
+    request: (method: string, path: string, body: unknown) => {
+      requests.push({ method, path, body });
+      return Promise.resolve(undefined);
+    },
+  } as unknown as HttpTransport;
+  return new PlaylistsClient(transport);
+}
+
+describe("PlaylistsClient.startPlaylist", () => {
+  it("sends every selected monitor name and never a wildcard", async () => {
+    const requests: CapturedRequest[] = [];
+    await clientCapturingRequests(requests).startPlaylist(7, ["DP-1", "DP-2"], false);
+
+    expect(requests[0].method).toBe("POST");
+    expect(requests[0].path).toBe("/playlists/7/start");
+    expect(requests[0].body).toEqual({ monitors: ["DP-1", "DP-2"], extend: false });
+  });
+
+  it("sends extend true when the selection spans monitors", async () => {
+    const requests: CapturedRequest[] = [];
+    await clientCapturingRequests(requests).startPlaylist(1, ["DP-1", "DP-2"], true);
+
+    expect(requests[0].body).toEqual({ monitors: ["DP-1", "DP-2"], extend: true });
+  });
+
+  it("sends an empty monitor list unchanged so the daemon expands it", async () => {
+    const requests: CapturedRequest[] = [];
+    await clientCapturingRequests(requests).startPlaylist(2, [], false);
+
+    expect(requests[0].body).toEqual({ monitors: [], extend: false });
+  });
+});

--- a/electron/daemonClient/playlistsClient.ts
+++ b/electron/daemonClient/playlistsClient.ts
@@ -1,7 +1,6 @@
 import type {
   ActivePlaylistInstance,
   CreatePlaylistRequest,
-  MonitorMode,
   Playlist,
   StartPlaylistRequest,
   UpdatePlaylistRequest,
@@ -31,14 +30,8 @@ export class PlaylistsClient {
     await this.t.request("DELETE", `/playlists/${id}`);
   }
 
-  async startPlaylist(
-    id: number,
-    monitor: string = "*",
-    mode: MonitorMode = "individual",
-  ): Promise<void> {
-    const body: StartPlaylistRequest = {
-      monitor: { id: monitor, mode },
-    };
+  async startPlaylist(id: number, monitors: string[], extend: boolean): Promise<void> {
+    const body: StartPlaylistRequest = { monitors, extend };
     await this.t.request("POST", `/playlists/${id}/start`, body);
   }
 

--- a/electron/goDaemonClient.ts
+++ b/electron/goDaemonClient.ts
@@ -341,12 +341,8 @@ class GoDaemonClient extends EventEmitter {
     return this.playlists.deletePlaylist(id);
   }
 
-  async startPlaylist(
-    id: number,
-    monitor: string = "*",
-    mode: MonitorMode = "individual",
-  ): Promise<void> {
-    return this.playlists.startPlaylist(id, monitor, mode);
+  async startPlaylist(id: number, monitors: string[], extend: boolean): Promise<void> {
+    return this.playlists.startPlaylist(id, monitors, extend);
   }
 
   async stopPlaylist(id: number): Promise<void> {

--- a/electron/ipc-types.ts
+++ b/electron/ipc-types.ts
@@ -105,7 +105,7 @@ export type DaemonRequest =
   | { type: "create_playlist"; playlist: CreatePlaylistRequest }
   | { type: "update_playlist"; id: number; update: UpdatePlaylistRequest }
   | { type: "delete_playlist"; id: number }
-  | { type: "start_playlist"; id: number; monitor?: string; mode?: MonitorMode }
+  | { type: "start_playlist"; id: number; monitors: string[]; extend: boolean }
   | { type: "stop_playlist"; id: number }
   | { type: "pause_playlist"; id: number }
   | { type: "resume_playlist"; id: number }

--- a/electron/managers/IPCManager.ts
+++ b/electron/managers/IPCManager.ts
@@ -619,11 +619,7 @@ export class IPCManager {
         case "delete_playlist":
           return await goDaemonClient.deletePlaylist(req.id);
         case "start_playlist":
-          return await goDaemonClient.startPlaylist(
-            req.id,
-            req.monitor || "*",
-            req.mode || "individual",
-          );
+          return await goDaemonClient.startPlaylist(req.id, req.monitors, req.extend);
         case "stop_playlist":
           return await goDaemonClient.stopPlaylist(req.id);
         case "pause_playlist":

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -151,13 +151,8 @@ const electronAPI = {
 
     deletePlaylist: (id: number): Promise<void> => invoke({ type: "delete_playlist", id }),
 
-    startPlaylist: (id: number, monitor?: string, mode?: MonitorMode): Promise<void> =>
-      invoke({
-        type: "start_playlist",
-        id,
-        monitor: monitor || "*",
-        mode: mode || "individual",
-      }),
+    startPlaylist: (id: number, monitors: string[], extend: boolean): Promise<void> =>
+      invoke({ type: "start_playlist", id, monitors, extend }),
 
     stopPlaylist: (id: number): Promise<void> => invoke({ type: "stop_playlist", id }),
 

--- a/src/components/LoadPlaylistModal.tsx
+++ b/src/components/LoadPlaylistModal.tsx
@@ -3,7 +3,6 @@ import { usePlaylistStore } from "../stores/playlist";
 import { useImagesStore } from "../stores/images";
 import { useShallow } from "zustand/react/shallow";
 import { useForm, useStore } from "@tanstack/react-form";
-import type { MonitorMode } from "../../electron/daemon-go-types";
 import { useMonitorStore } from "../stores/monitors";
 import type { Playlist } from "../../electron/daemon-go-types";
 import Modal, { type ModalHandle } from "./Modal";
@@ -25,12 +24,12 @@ type LoadPlaylistResult =
 
 async function loadAndStartPlaylist(
   playlistId: number,
-  monitor: string,
-  mode: MonitorMode | undefined,
+  monitors: string[],
+  extend: boolean,
 ): Promise<LoadPlaylistResult> {
   try {
     const fullPlaylist = await daemonClient.getPlaylist(playlistId);
-    await daemonClient.startPlaylist(fullPlaylist.id, monitor, mode);
+    await daemonClient.startPlaylist(fullPlaylist.id, monitors, extend);
     return {
       ok: true,
       playlist: {
@@ -80,12 +79,10 @@ const LoadPlaylistModal = ({ playlistsInDB, onPlaylistChanged, currentPlaylistNa
         return;
       }
 
-      const monitor =
-        monitorSelection.selectedMonitors.length === 1 ? monitorSelection.selectedMonitors[0] : "*";
       const result = await loadAndStartPlaylist(
         selectedPlaylist.id,
-        monitor,
-        monitorSelection.mode,
+        monitorSelection.selectedMonitors,
+        monitorSelection.mode === "extend",
       );
       if (result.ok) {
         clearPlaylist();

--- a/src/components/SavePlaylistModal.tsx
+++ b/src/components/SavePlaylistModal.tsx
@@ -67,8 +67,7 @@ const SavePlaylistModal = ({ currentPlaylistName, onPlaylistChanged }: Props) =>
           showError({ state: false, message: "" });
         }
       }
-      const monitorTarget =
-        monitorSelection.selectedMonitors.length === 1 ? monitorSelection.selectedMonitors[0] : "*";
+      const extend = monitorSelection.mode === "extend";
       try {
         let savedId: number;
         let activeAfterSave: ActivePlaylistInstance[] | undefined;
@@ -112,12 +111,12 @@ const SavePlaylistModal = ({ currentPlaylistName, onPlaylistChanged }: Props) =>
               playlistType: playlist.configuration.type,
               activePlaylists: activeAfterSave ?? [],
               selectedMonitors: monitorSelection.selectedMonitors,
-              mode: monitorSelection.mode,
+              extend,
             });
           }
           if (!skipStart) {
             try {
-              await daemonClient.startPlaylist(savedId, monitorTarget, monitorSelection.mode);
+              await daemonClient.startPlaylist(savedId, monitorSelection.selectedMonitors, extend);
             } catch (startErr) {
               logger.error("Failed to start playlist:", startErr);
             }

--- a/src/hooks/__tests__/monitorSetsMatch.test.ts
+++ b/src/hooks/__tests__/monitorSetsMatch.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { monitorSetsMatch } from "../useSetLastActivePlaylist";
+
+describe("monitorSetsMatch", () => {
+  it("matches identical monitor sets", () => {
+    expect(monitorSetsMatch(["DP-1"], ["DP-1"])).toBe(true);
+  });
+
+  it("matches regardless of order", () => {
+    expect(monitorSetsMatch(["DP-1", "DP-2"], ["DP-2", "DP-1"])).toBe(true);
+  });
+
+  it("rejects a subset", () => {
+    expect(monitorSetsMatch(["DP-1"], ["DP-1", "DP-2"])).toBe(false);
+  });
+
+  it("rejects disjoint sets of the same size", () => {
+    expect(monitorSetsMatch(["DP-1"], ["HDMI-A-1"])).toBe(false);
+  });
+});

--- a/src/hooks/useSetLastActivePlaylist.ts
+++ b/src/hooks/useSetLastActivePlaylist.ts
@@ -5,16 +5,10 @@ import { useActivePlaylistStore } from "../stores/activePlaylistStore";
 import { useShallow } from "zustand/react/shallow";
 import type { rendererPlaylist } from "../types/rendererTypes";
 import { useEffect } from "react";
-import type { ActivePlaylistInstance, MonitorMode } from "../../electron/daemon-go-types";
+import type { ActivePlaylistInstance } from "../../electron/daemon-go-types";
 import { daemonClient } from "@/client";
 
-function monitorSetsMatch(
-  selected: string[],
-  selectedMode: MonitorMode,
-  playlistMonitors: string[],
-  playlistMode: MonitorMode,
-): boolean {
-  if (selectedMode !== playlistMode) return false;
+export function monitorSetsMatch(selected: string[], playlistMonitors: string[]): boolean {
   if (selected.length !== playlistMonitors.length) return false;
   const a = new Set(selected);
   return playlistMonitors.every((m) => a.has(m));
@@ -28,7 +22,7 @@ function monitorSetsMatch(
  * events published during the gap were dropped and never reached those listeners.
  */
 export async function refreshActivePlaylist(): Promise<void> {
-  const { selectedMonitors, mode } = useMonitorStore.getState().monitorSelection;
+  const { selectedMonitors } = useMonitorStore.getState().monitorSelection;
   if (selectedMonitors.length === 0) {
     usePlaylistStore.getState().clearPlaylist();
     useActivePlaylistStore.getState().clear();
@@ -48,9 +42,7 @@ export async function refreshActivePlaylist(): Promise<void> {
     return;
   }
 
-  const match = activePlaylists.find((ap) =>
-    monitorSetsMatch(selectedMonitors, mode, ap.monitors, ap.mode),
-  );
+  const match = activePlaylists.find((ap) => monitorSetsMatch(selectedMonitors, ap.monitors));
 
   if (!match) {
     usePlaylistStore.getState().clearPlaylist();
@@ -116,12 +108,7 @@ export function useSetLastActivePlaylist() {
         }
 
         const match = activePlaylists.find((ap) =>
-          monitorSetsMatch(
-            monitorSelection.selectedMonitors,
-            monitorSelection.mode,
-            ap.monitors,
-            ap.mode,
-          ),
+          monitorSetsMatch(monitorSelection.selectedMonitors, ap.monitors),
         );
 
         if (!match) {

--- a/src/stores/__tests__/activePlaylistStore.test.ts
+++ b/src/stores/__tests__/activePlaylistStore.test.ts
@@ -24,11 +24,12 @@ describe("useActivePlaylistStore", () => {
     next_image_id: 43,
     total_images: 5,
     paused: false,
-    mode: "individual",
     started_at: new Date().toISOString(),
     next_change_at: null,
     slot_started_at: null,
     monitors: ["HDMI-A-1"],
+    applied_to: ["HDMI-A-1"],
+    extend: false,
   };
 
   it("initial state loads from localStorage", async () => {

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -98,7 +98,7 @@ declare global {
         createPlaylist: (playlist: CreatePlaylistRequest) => Promise<Playlist>;
         updatePlaylist: (id: number, update: UpdatePlaylistRequest) => Promise<Playlist>;
         deletePlaylist: (id: number) => Promise<void>;
-        startPlaylist: (id: number, monitor?: string, mode?: MonitorMode) => Promise<void>;
+        startPlaylist: (id: number, monitors: string[], extend: boolean) => Promise<void>;
         stopPlaylist: (id: number) => Promise<void>;
         pausePlaylist: (id: number) => Promise<void>;
         resumePlaylist: (id: number) => Promise<void>;

--- a/src/utils/__tests__/skipStartAfterPlaylistSave.test.ts
+++ b/src/utils/__tests__/skipStartAfterPlaylistSave.test.ts
@@ -11,11 +11,12 @@ const baseActive = (over: Partial<ActivePlaylistInstance>): ActivePlaylistInstan
   next_image_id: null,
   total_images: 3,
   paused: false,
-  mode: "individual",
   started_at: new Date().toISOString(),
   next_change_at: null,
   slot_started_at: null,
   monitors: ["DP-1"],
+  applied_to: ["DP-1"],
+  extend: false,
   ...over,
 });
 
@@ -27,7 +28,7 @@ describe("shouldSkipPlaylistStartAfterUpdate", () => {
         playlistType: "manual",
         activePlaylists: [baseActive({})],
         selectedMonitors: ["DP-1"],
-        mode: "individual",
+        extend: false,
       }),
     ).toBe(true);
   });
@@ -39,7 +40,7 @@ describe("shouldSkipPlaylistStartAfterUpdate", () => {
         playlistType: "time_of_day",
         activePlaylists: [baseActive({})],
         selectedMonitors: ["DP-1"],
-        mode: "individual",
+        extend: false,
       }),
     ).toBe(true);
   });
@@ -51,19 +52,19 @@ describe("shouldSkipPlaylistStartAfterUpdate", () => {
         playlistType: "timer",
         activePlaylists: [baseActive({ playlist_id: 1 })],
         selectedMonitors: ["DP-1"],
-        mode: "individual",
+        extend: false,
       }),
     ).toBe(false);
   });
 
-  it("returns false when mode differs", () => {
+  it("returns false when extend differs", () => {
     expect(
       shouldSkipPlaylistStartAfterUpdate({
         savedId: 1,
         playlistType: "timer",
-        activePlaylists: [baseActive({ mode: "individual" })],
-        selectedMonitors: ["DP-1"],
-        mode: "span",
+        activePlaylists: [baseActive({ monitors: ["DP-1", "DP-2"], extend: false })],
+        selectedMonitors: ["DP-1", "DP-2"],
+        extend: true,
       }),
     ).toBe(false);
   });
@@ -75,19 +76,31 @@ describe("shouldSkipPlaylistStartAfterUpdate", () => {
         playlistType: "timer",
         activePlaylists: [baseActive({ monitors: ["DP-1", "HDMI-A-1"] })],
         selectedMonitors: ["DP-1"],
-        mode: "individual",
+        extend: false,
       }),
     ).toBe(false);
   });
 
-  it("returns true for timer with same monitors (order-insensitive) and mode", () => {
+  it("returns true for timer with same monitors (order-insensitive)", () => {
     expect(
       shouldSkipPlaylistStartAfterUpdate({
         savedId: 1,
         playlistType: "timer",
         activePlaylists: [baseActive({ monitors: ["HDMI-A-1", "DP-1"] })],
         selectedMonitors: ["DP-1", "HDMI-A-1"],
-        mode: "individual",
+        extend: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("compares the declared monitor set, not the applied subset", () => {
+    expect(
+      shouldSkipPlaylistStartAfterUpdate({
+        savedId: 1,
+        playlistType: "timer",
+        activePlaylists: [baseActive({ monitors: ["DP-1", "DP-2"], applied_to: ["DP-1"] })],
+        selectedMonitors: ["DP-1", "DP-2"],
+        extend: false,
       }),
     ).toBe(true);
   });

--- a/src/utils/skipStartAfterPlaylistSave.ts
+++ b/src/utils/skipStartAfterPlaylistSave.ts
@@ -15,13 +15,13 @@ export function shouldSkipPlaylistStartAfterUpdate(opts: {
   playlistType: string;
   activePlaylists: ActivePlaylistInstance[];
   selectedMonitors: string[];
-  mode: string;
+  extend: boolean;
 }): boolean {
   const active = opts.activePlaylists.find((ap) => ap.playlist_id === opts.savedId);
   if (!active) {
     return false;
   }
-  if (active.mode !== opts.mode) {
+  if (active.extend !== opts.extend) {
     return false;
   }
   return sortedMonitorSetsEqual(active.monitors, opts.selectedMonitors);


### PR DESCRIPTION
## Problem

A playlist target was `{id: "*" | name, mode}` — `"*"` being a late-bound query resolved against whatever monitors were connected at that instant. The resolved set was then persisted as if it were the user's request.

Observed: a daemon restart while DP-2 was asleep started the playlist on `["DP-1"]`, persisted that, and every later restart read it back as intent — pinning the playlist to DP-1 even once DP-2 returned. It also produced `mode: "clone"` over a one-monitor set, an impossible state the UI can't match, so the playlist ran invisibly to the GUI.

Related: `"*"` meant *all connected* monitors, never *the selected* ones, so selecting 2 of 3 monitors applied to all 3.

## Change

A target is now an explicit monitor list plus an `extend` flag. Runs record the declared set and the applied subset separately, and only the declared set is persisted — a monitor absent at start no longer rewrites what the user asked for.

`mode` is gone from the playlist path. `individual` was never a sibling of clone/extend: clone/extend describe how one group shares an image, `individual` described how many groups exist. Collapsing it to `extend bool` makes the impossible state unrepresentable rather than validated.

## API

```
POST /playlists/{id}/start   {"monitors": ["DP-1","DP-2"], "extend": false}
```
`monitors` omitted or empty expands to all connected, once, in the handler. Names not currently connected are kept in the declared set. 400 only when none is connected.

Active playlist responses drop `mode` and gain `applied_to` and `extend`; `monitors` now means the declared set. `playlist_started` SSE follows. `API_CONTRACT.md` updated.

## Verification

- `gofmt -l` clean, `go build ./...`, all 32 daemon packages pass
- 461 renderer tests, `tsc --noEmit` clean, lint and format clean
- End to end against the built binary with `HDMI-A-1` physically disconnected: declared `["DP-1","HDMI-A-1"]` / `applied_to ["DP-1"]`, byte-identical across two restarts

Net −29 implementation lines.

## Notes

- `MonitorMode` and `NormalizeMode` remain for the static-wallpaper path, which is out of scope here.
- Collision detection now compares declared sets rather than resolved ones, so two playlists can't both claim a sleeping monitor.
- No migration: playback rows lacking `extend` decode to `false`, which is the previous clone behaviour.
- A live degraded run still won't re-expand when a monitor returns — the daemon has no hotplug handling yet. Follow-up.
